### PR TITLE
Implement base build and input stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.14)
+project(SymbolCast LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Core library (header-only)
+add_library(symbolcast_core INTERFACE)
+target_include_directories(symbolcast_core INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Desktop application
+add_executable(symbolcast-desktop apps/desktop/main.cpp)
+target_link_libraries(symbolcast-desktop PRIVATE symbolcast_core)
+
+# VR application
+add_executable(symbolcast-vr apps/vr/main.cpp)
+target_link_libraries(symbolcast-vr PRIVATE symbolcast_core)
+
+# Tests
+add_executable(symbolcast-tests tests/test_symbol_match.cpp)
+target_link_libraries(symbolcast-tests PRIVATE symbolcast_core)
+add_test(NAME SymbolCastTests COMMAND symbolcast-tests)
+
+enable_testing()

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ make
 ./symbolcast-desktop
 ```
 
+### Build and run the VR app
+```bash
+make symbolcast-vr
+./symbolcast-vr
+```
+
 
 ---
 

--- a/apps/desktop/main.cpp
+++ b/apps/desktop/main.cpp
@@ -1,0 +1,16 @@
+#include "core/input/InputManager.hpp"
+#include "core/recognition/ModelRunner.hpp"
+#include "utils/Logger.hpp"
+
+int main() {
+    sc::log(sc::LogLevel::Info, "SymbolCast Desktop starting");
+    sc::InputManager input;
+    sc::ModelRunner model;
+    model.loadModel("models/lite/symbolcast-v1.onnx");
+    input.startCapture();
+    input.addPoint(0, 0);
+    input.addPoint(1, 1);
+    auto command = model.run(input.points());
+    sc::log(sc::LogLevel::Info, std::string("Predicted command: ") + command);
+    return 0;
+}

--- a/apps/vr/main.cpp
+++ b/apps/vr/main.cpp
@@ -1,0 +1,12 @@
+#include "core/input/InputManager.hpp"
+#include "utils/Logger.hpp"
+
+int main() {
+    sc::log(sc::LogLevel::Info, "SymbolCast VR starting");
+    sc::InputManager input;
+    input.startCapture();
+    input.addPoint(0, 0);
+    input.addPoint(0, 1);
+    sc::log(sc::LogLevel::Info, "Captured simple vertical gesture");
+    return 0;
+}

--- a/core/input/InputManager.hpp
+++ b/core/input/InputManager.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include <utility>
+#include <vector>
+
+namespace sc {
+
+// Simple 2D point
+struct Point {
+    float x;
+    float y;
+};
+
+// InputManager records gesture points for later recognition or training.
+class InputManager {
+public:
+    void startCapture() { m_points.clear(); }
+
+    void addPoint(float x, float y) {
+        m_points.push_back({x, y});
+    }
+
+    const std::vector<Point>& points() const { return m_points; }
+
+    void clear() { m_points.clear(); }
+
+private:
+    std::vector<Point> m_points;
+};
+
+} // namespace sc

--- a/core/recognition/ModelRunner.hpp
+++ b/core/recognition/ModelRunner.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "../input/InputManager.hpp"
+
+namespace sc {
+
+// Stub model runner for loading and running gesture recognition models.
+class ModelRunner {
+public:
+    bool loadModel(const std::string& path) {
+        m_modelPath = path;
+        // In a real implementation we would load the ONNX model here.
+        return true;
+    }
+
+    // Returns a dummy command string for now.
+    std::string run(const std::vector<Point>& points) {
+        if (points.empty()) return "";
+        // Real inference would happen here.
+        return "dummy-command";
+    }
+
+    const std::string& modelPath() const { return m_modelPath; }
+
+private:
+    std::string m_modelPath;
+};
+
+} // namespace sc

--- a/scripts/training/train_symbol_model.py
+++ b/scripts/training/train_symbol_model.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Dummy training script for SymbolCast models."""
+import argparse
+from pathlib import Path
+
+def main():
+    parser = argparse.ArgumentParser(description="Train symbol recognition model")
+    parser.add_argument("--data_dir", required=True)
+    parser.add_argument("--output_model", required=True)
+    args = parser.parse_args()
+
+    output = Path(args.output_model)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with open(output, "w") as f:
+        f.write("placeholder model data")
+    print(f"Model written to {output}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_symbol_match.cpp
+++ b/tests/test_symbol_match.cpp
@@ -1,0 +1,11 @@
+#include "core/input/InputManager.hpp"
+#include <cassert>
+
+int main() {
+    sc::InputManager mgr;
+    mgr.startCapture();
+    mgr.addPoint(0.f, 0.f);
+    mgr.addPoint(1.f, 1.f);
+    assert(mgr.points().size() == 2);
+    return 0;
+}

--- a/utils/Logger.hpp
+++ b/utils/Logger.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <iostream>
+
+namespace sc {
+
+enum class LogLevel { Info, Warn, Error };
+
+inline void log(LogLevel level, const std::string& msg) {
+    switch (level) {
+    case LogLevel::Info:
+        std::cout << "[INFO] " << msg << std::endl;
+        break;
+    case LogLevel::Warn:
+        std::cout << "[WARN] " << msg << std::endl;
+        break;
+    case LogLevel::Error:
+        std::cerr << "[ERROR] " << msg << std::endl;
+        break;
+    }
+}
+
+} // namespace sc


### PR DESCRIPTION
## Summary
- create CMake build producing desktop/VR apps and tests
- implement simple `InputManager`, `ModelRunner`, and `Logger` utilities
- add sample desktop and VR app entry points
- provide a dummy training script
- document how to build and run the VR app

## Testing
- `cmake .. && make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68436d14ac5c832f9584be58d8eadcb7