### PR TITLE
Reset trace after finger lift

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ make
 ```
 
 An overlay window sized to your trackpad will appear and your system cursor will be hidden inside it. Any finger motion creates a fading ripple so you can practice moving on the pad. Double tap (or double click) to begin drawing; your movements are captured even without holding the button. Double tap again to submit the glowing trace for recognition.
+Lifting your finger while drawing clears the current trace so you can reposition and start a new one without leaving drawing mode.
 
 
 ### Build and run the VR app

--- a/apps/desktop/CanvasWindow.hpp
+++ b/apps/desktop/CanvasWindow.hpp
@@ -79,6 +79,11 @@ protected:
     }
     void mouseReleaseEvent(QMouseEvent* event) override {
         Q_UNUSED(event);
+        if (m_input.capturing()) {
+            m_input.clear();
+            m_points.clear();
+            update();
+        }
     }
     void paintEvent(QPaintEvent*) override {
         QPainter p(this);


### PR DESCRIPTION
## Summary
- clear drawing points when finger is lifted
- document that lifting your finger resets the trace in the README

## Testing
- `cmake ..` *(fails: Could not find Qt5)*

------
https://chatgpt.com/codex/tasks/task_e_6844c1d25878832f9bd021d2f24f20a8