### PR TITLE
Add user-configurable drawing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ make
 An overlay window sized to your trackpad will appear and your system cursor will be hidden inside it. Any finger motion creates a fading ripple so you can practice moving on the pad. Double tap (or double click) to begin drawing; your movements are captured even without holding the button. Double tap again to submit the glowing trace for recognition.
 Lifting your finger while drawing clears the current trace so you can reposition and start a new one without leaving drawing mode.
 
+#### Command-line options
+
+You can customize the appearance of ripples and strokes:
+
+```
+--ripple-growth <rate>   Ripple growth per frame (default: 2.0)
+--ripple-max <radius>    Maximum ripple radius (default: 80)
+--ripple-color <hex>     Ripple color in hex (default: #ffffff96)
+--stroke-width <px>      Stroke width in pixels (default: 3)
+--stroke-color <hex>     Stroke color in hex (default: #ffffff)
+--fade-rate <rate>       Stroke fade per frame (default: 0.005)
+```
+
 An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a white glowing trace follows your finger and gradually fades away so you can write multi-stroke symbols. Double tap again to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.
 
 An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a white glowing trace follows your finger and gradually fades away so you can write multi-stroke symbols. Double tap again to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.

--- a/apps/desktop/CanvasWindow.hpp
+++ b/apps/desktop/CanvasWindow.hpp
@@ -11,6 +11,7 @@
 #include <QPainterPath>
 #include <QPushButton>
 #include <QLabel>
+#include <QColor>
 #include <QResizeEvent>
 #include <QShortcut>
 #include <QTimer>
@@ -21,8 +22,17 @@
 class CanvasWindow : public QWidget {
   Q_OBJECT
 public:
-  explicit CanvasWindow(QWidget *parent = nullptr)
-      : QWidget(parent), m_dragging(false), m_resizing(false),
+  struct Options {
+    float rippleGrowthRate{2.f};
+    float rippleMaxRadius{80.f};
+    QColor rippleColor{255, 255, 255, 150};
+    int strokeWidth{3};
+    QColor strokeColor{255, 255, 255};
+    float fadeRate{0.005f};
+  };
+
+  explicit CanvasWindow(const Options &opts = Options(), QWidget *parent = nullptr)
+      : QWidget(parent), m_options(opts), m_dragging(false), m_resizing(false),
         m_pressPending(false), m_resizeEdges(0), m_borderWidth(2) {
     setAttribute(Qt::WA_TranslucentBackground);
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint |
@@ -236,7 +246,8 @@ protected:
     p.setClipPath(path);
     // ripples
     for (auto &r : m_ripples) {
-      QColor c(255, 255, 255, static_cast<int>(150 * r.opacity));
+      QColor c = m_options.rippleColor;
+      c.setAlphaF(c.alphaF() * r.opacity);
       p.setPen(Qt::NoPen);
       p.setBrush(c);
       p.drawEllipse(r.pos, r.radius, r.radius);
@@ -245,8 +256,9 @@ protected:
     for (const auto &s : m_strokes) {
       if (s.points.empty())
         continue;
-      QColor col(255, 255, 255, static_cast<int>(255 * s.opacity));
-      QPen pen(col, 3);
+      QColor col = m_options.strokeColor;
+      col.setAlphaF(col.alphaF() * s.opacity);
+      QPen pen(col, m_options.strokeWidth);
       p.setPen(pen);
       if (s.points.size() == 1) {
         p.drawEllipse(s.points[0], 2, 2);
@@ -276,15 +288,16 @@ private slots:
   }
   void onFrame() {
     for (auto &r : m_ripples) {
-      r.radius += 2.0f;
+      r.radius += m_options.rippleGrowthRate;
       r.opacity -= 0.05f;
     }
     m_ripples.erase(
-        std::remove_if(m_ripples.begin(), m_ripples.end(),
-                       [](const Ripple &r) { return r.opacity <= 0.f; }),
+        std::remove_if(m_ripples.begin(), m_ripples.end(), [&](const Ripple &r) {
+          return r.opacity <= 0.f || r.radius >= m_options.rippleMaxRadius;
+        }),
         m_ripples.end());
     for (auto &s : m_strokes)
-      s.opacity -= m_fadeRate;
+      s.opacity -= m_options.fadeRate;
     m_strokes.erase(std::remove_if(m_strokes.begin(), m_strokes.end(),
                                    [&](const Stroke &s) {
                                      return s.opacity <= 0.f;
@@ -324,7 +337,7 @@ private:
     float opacity{1.f};
   };
   std::vector<Stroke> m_strokes;
-  float m_fadeRate{0.005f};
+  Options m_options;
   std::vector<Ripple> m_ripples;
   QTimer *m_timer;
   QTimer *m_idleTimer;

--- a/apps/desktop/main.cpp
+++ b/apps/desktop/main.cpp
@@ -1,11 +1,49 @@
 #include <QApplication>
 #include "CanvasWindow.hpp"
+#include <QCommandLineOption>
+#include <QCommandLineParser>
 #include "utils/Logger.hpp"
 
 int main(int argc, char** argv) {
     QApplication app(argc, argv);
+    QCommandLineParser parser;
+    parser.setApplicationDescription("SymbolCast desktop app");
+    parser.addHelpOption();
+
+    QCommandLineOption rippleGrowthOpt({"g", "ripple-growth"},
+        "Ripple growth per frame", "rate", "2.0");
+    QCommandLineOption rippleMaxOpt({"m", "ripple-max"},
+        "Maximum ripple radius", "radius", "80.0");
+    QCommandLineOption rippleColorOpt({"c", "ripple-color"},
+        "Ripple color (hex)", "color", "#ffffff96");
+    QCommandLineOption strokeWidthOpt({"w", "stroke-width"},
+        "Stroke width", "width", "3");
+    QCommandLineOption strokeColorOpt({"s", "stroke-color"},
+        "Stroke color (hex)", "color", "#ffffff");
+    QCommandLineOption fadeRateOpt({"f", "fade-rate"},
+        "Stroke fade per frame", "rate", "0.005");
+
+    parser.addOption(rippleGrowthOpt);
+    parser.addOption(rippleMaxOpt);
+    parser.addOption(rippleColorOpt);
+    parser.addOption(strokeWidthOpt);
+    parser.addOption(strokeColorOpt);
+    parser.addOption(fadeRateOpt);
+
+    parser.process(app);
+
+    CanvasWindow::Options opts;
+    opts.rippleGrowthRate = parser.value(rippleGrowthOpt).toFloat();
+    opts.rippleMaxRadius = parser.value(rippleMaxOpt).toFloat();
+    opts.rippleColor = QColor(parser.value(rippleColorOpt));
+    if (!opts.rippleColor.isValid()) opts.rippleColor = QColor("#ffffff96");
+    opts.strokeWidth = parser.value(strokeWidthOpt).toInt();
+    opts.strokeColor = QColor(parser.value(strokeColorOpt));
+    if (!opts.strokeColor.isValid()) opts.strokeColor = QColor("#ffffff");
+    opts.fadeRate = parser.value(fadeRateOpt).toFloat();
+
     sc::log(sc::LogLevel::Info, "SymbolCast Desktop starting");
-    CanvasWindow win;
+    CanvasWindow win(opts);
     win.show();
     return app.exec();
 }


### PR DESCRIPTION
## Summary
- add configurable options struct to `CanvasWindow`
- use options for ripple growth, color, maximum radius and stroke fade
- parse new command-line flags in `symbolcast-desktop`
- document command-line flags in README

## Testing
- `cmake ..` *(fails: Qt not found)*
- `ctest --output-on-failure` *(no tests run due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_6845e4239308832fbbe2e478cc86ec2f