### PR TITLE
Add configurable command mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ make
 ```
 An overlay window sized to your trackpad will appear and your system cursor will be hidden inside it. Any finger motion creates a fading ripple so you can practice moving on the pad. Double tap (or double click) to begin drawing; your movements are captured even without holding the button. Double tap again to submit the glowing trace for recognition.
 Lifting your finger while drawing clears the current trace so you can reposition and start a new one without leaving drawing mode.
+### Configuration
+
+SymbolCast loads command mappings from `config/commands.json` when it starts.
+Edit this file to change which command is triggered for each recognized symbol.
+
 
 An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a white glowing trace follows your finger and gradually fades away so you can write multi-stroke symbols. Double tap again to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.
 

--- a/config/commands.json
+++ b/config/commands.json
@@ -1,0 +1,5 @@
+{
+    "triangle": "open-settings",
+    "dot": "click",
+    "square": "open-menu"
+}

--- a/tests/test_command_mapping.cpp
+++ b/tests/test_command_mapping.cpp
@@ -1,5 +1,6 @@
 #include "core/recognition/ModelRunner.hpp"
 #include <cassert>
+#include <fstream>
 
 int main() {
     sc::ModelRunner runner;
@@ -7,5 +8,14 @@ int main() {
     assert(runner.commandForSymbol("dot") == "click");
     assert(runner.commandForSymbol("square") == "open-menu");
     assert(runner.commandForSymbol("unknown").empty());
+
+    std::ofstream out("commands_test.json");
+    out << "{ \"triangle\": \"launch\", \"new\": \"custom\" }";
+    out.close();
+
+    sc::ModelRunner custom("commands_test.json");
+    assert(custom.commandForSymbol("triangle") == "launch");
+    assert(custom.commandForSymbol("square") == "open-menu");
+    assert(custom.commandForSymbol("new") == "custom");
     return 0;
 }


### PR DESCRIPTION
## Summary
- allow ModelRunner to load command mappings from `config/commands.json`
- test that custom mappings override defaults
- add default `commands.json`
- document configuration in README

## Testing
- `g++ -std=c++17 -I. tests/test_command_mapping.cpp -o test_command_mapping && ./test_command_mapping`
- `g++ -std=c++17 -I. tests/test_symbol_match.cpp -o test_symbol_match && ./test_symbol_match`
- `g++ -std=c++17 -I. tests/test_vr_capture.cpp -o test_vr_capture && ./test_vr_capture`
- `g++ -std=c++17 -I. tests/test_double_tap.cpp -o test_double_tap && ./test_double_tap`
- `g++ -std=c++17 -I. tests/test_timestamp.cpp -o test_timestamp && ./test_timestamp`


------
https://chatgpt.com/codex/tasks/task_e_6845e933abd0832fa80463a5cb026711