### PR TITLE
Refactor CanvasWindow options struct

### DIFF
--- a/apps/desktop/CanvasWindow.hpp
+++ b/apps/desktop/CanvasWindow.hpp
@@ -19,19 +19,20 @@
 #include <algorithm>
 #include <vector>
 
+struct CanvasWindowOptions {
+  float rippleGrowthRate{2.f};
+  float rippleMaxRadius{80.f};
+  QColor rippleColor{255, 255, 255, 150};
+  int strokeWidth{3};
+  QColor strokeColor{255, 255, 255};
+  float fadeRate{0.005f};
+};
+
 class CanvasWindow : public QWidget {
   Q_OBJECT
 public:
-  struct Options {
-    float rippleGrowthRate{2.f};
-    float rippleMaxRadius{80.f};
-    QColor rippleColor{255, 255, 255, 150};
-    int strokeWidth{3};
-    QColor strokeColor{255, 255, 255};
-    float fadeRate{0.005f};
-  };
 
-  explicit CanvasWindow(const Options &opts = Options(), QWidget *parent = nullptr)
+  explicit CanvasWindow(const CanvasWindowOptions &opts = CanvasWindowOptions(), QWidget *parent = nullptr)
       : QWidget(parent), m_options(opts), m_dragging(false), m_resizing(false),
         m_pressPending(false), m_resizeEdges(0), m_borderWidth(2) {
     setAttribute(Qt::WA_TranslucentBackground);
@@ -376,7 +377,7 @@ private:
     }
   };
   std::vector<Stroke> m_strokes;
-  Options m_options;
+  CanvasWindowOptions m_options;
   std::vector<Ripple> m_ripples;
   QTimer *m_timer;
   QTimer *m_idleTimer;

--- a/apps/desktop/main.cpp
+++ b/apps/desktop/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
 
     parser.process(app);
 
-    CanvasWindow::Options opts;
+    CanvasWindowOptions opts;
     opts.rippleGrowthRate = parser.value(rippleGrowthOpt).toFloat();
     opts.rippleMaxRadius = parser.value(rippleMaxOpt).toFloat();
     opts.rippleColor = QColor(parser.value(rippleColorOpt));


### PR DESCRIPTION
## Summary
- introduce `CanvasWindowOptions` struct
- update `CanvasWindow` to use the new struct
- adjust desktop app to use `CanvasWindowOptions`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6845f2b1d484832f9065044d0772d0a8