### PR TITLE
Modify capture behavior and add prediction overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ make
 ```bash
 ./symbolcast-desktop
 ```
-An overlay window sized to your trackpad will appear and your system cursor will be hidden inside it. Any finger motion creates a fading ripple so you can practice moving on the pad. Double tap (or double click) to begin drawing; your movements are captured even without holding the button. Double tap again to submit the glowing trace for recognition.
+An overlay window sized to your trackpad will appear and your system cursor will be hidden inside it. Any finger motion creates a fading ripple so you can practice moving on the pad. Double tap (or double click) to begin drawing; your movements are captured even without holding the button. Tap once to submit the glowing trace for recognition.
 Lifting your finger while drawing clears the current trace so you can reposition and start a new one without leaving drawing mode.
 
 ### Configuration
@@ -80,10 +80,7 @@ You can customize the appearance of ripples and strokes:
 --fade-rate <rate>       Stroke fade per frame (default: 0.005)
 ```
 
-An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a white glowing trace follows your finger and gradually fades away so you can write multi-stroke symbols. Double tap again to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.
-
-
-An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a white glowing trace follows your finger and gradually fades away so you can write multi-stroke symbols. Double tap again to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.
+An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a white glowing trace follows your finger and gradually fades away so you can write multi-stroke symbols. Tap once to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.
 
 ### Build and run the VR app
 ```bash

--- a/core/input/InputManager.hpp
+++ b/core/input/InputManager.hpp
@@ -25,19 +25,26 @@ public:
           m_doubleTapInterval(intervalMs) {}
 
     // Handle a tap event with timestamp in milliseconds. Returns true if
-    // a double tap was detected. A double tap toggles capture on/off.
+    // a double tap was detected. Two taps start capture, a single tap
+    // while capturing stops it.
     bool onTap(uint64_t timestamp) {
         if (timestamp < m_lastTap)
             m_lastTap = std::numeric_limits<uint64_t>::max(); // reset if timestamps go backwards
+
+        if (m_capturing) {
+            // any tap while capturing ends the capture
+            stopCapture();
+            m_lastTap = std::numeric_limits<uint64_t>::max();
+            return false;
+        }
+
         if (m_lastTap != std::numeric_limits<uint64_t>::max() &&
             timestamp - m_lastTap < m_doubleTapInterval) {
-            if (m_capturing)
-                stopCapture();
-            else
-                startCapture();
+            startCapture();
             m_lastTap = std::numeric_limits<uint64_t>::max();
             return true;
         }
+
         m_lastTap = timestamp;
         return false;
     }

--- a/tests/test_double_tap.cpp
+++ b/tests/test_double_tap.cpp
@@ -3,17 +3,20 @@
 
 int main() {
     sc::InputManager mgr;
-    bool start = mgr.onTap(10);
-    assert(!start && !mgr.capturing());
-    start = mgr.onTap(20); // within interval -> start capture
-    assert(start && mgr.capturing());
-    // second double tap should stop capture
-    start = mgr.onTap(30);
-    assert(!start); // single tap
-    start = mgr.onTap(40); // double tap -> stop
-    assert(start && !mgr.capturing());
-    // far apart -> not a double tap
-    start = mgr.onTap(400);
-    assert(!start && !mgr.capturing());
+    bool dbl = mgr.onTap(10);
+    assert(!dbl && !mgr.capturing());
+    dbl = mgr.onTap(20); // second tap -> start capture
+    assert(dbl && mgr.capturing());
+    // single tap stops capture
+    dbl = mgr.onTap(50);
+    assert(!dbl && !mgr.capturing());
+    // start again
+    dbl = mgr.onTap(100);
+    assert(!dbl && !mgr.capturing());
+    dbl = mgr.onTap(140);
+    assert(dbl && mgr.capturing());
+    // another single tap end
+    dbl = mgr.onTap(200);
+    assert(!dbl && !mgr.capturing());
     return 0;
 }

--- a/tests/test_timestamp.cpp
+++ b/tests/test_timestamp.cpp
@@ -4,9 +4,9 @@
 int main() {
     sc::InputManager mgr(100);
     mgr.onTap(100);
-    // going backwards should reset internal state
-    assert(!mgr.onTap(50));
-    mgr.onTap(200);
-    assert(mgr.onTap(250));
+    // going backwards should reset internal state and not start capture
+    assert(!mgr.onTap(50) && !mgr.capturing());
+    mgr.onTap(200);           // first tap
+    assert(mgr.onTap(250) && mgr.capturing());
     return 0;
 }


### PR DESCRIPTION
## Summary
- switch to double-tap start and single-tap submit
- default stroke color matches window border
- tint canvas background and add prediction overlay
- update instructions and tests for new behaviour

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6845f7892c40832faf3aaf750e4e1b87