### PR TITLE
Update canvas UI theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ You can customize the appearance of ripples and strokes:
 ```
 --ripple-growth <rate>   Ripple growth per frame (default: 2.0)
 --ripple-max <radius>    Maximum ripple radius (default: 80)
---ripple-color <hex>     Ripple color in hex (default: #ffffff96)
+--ripple-color <hex>     Ripple color in hex (default: #fffbe096)
 --stroke-width <px>      Stroke width in pixels (default: 3)
---stroke-color <hex>     Stroke color in hex (default: #ffffff)
+--stroke-color <hex>     Stroke color in hex (default: #fffbe0)
 --fade-rate <rate>       Stroke fade per frame (default: 0.005)
 ```
 
-An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a white glowing trace follows your finger and gradually fades away so you can write multi-stroke symbols. Tap once to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.
+An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a soft yellow trace follows your finger and gradually fades away so you can write multi-stroke symbols. Tap once to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.
 
 ### Build and run the VR app
 ```bash

--- a/apps/desktop/CanvasWindow.hpp
+++ b/apps/desktop/CanvasWindow.hpp
@@ -22,11 +22,11 @@
 struct CanvasWindowOptions {
   float rippleGrowthRate{2.f};
   float rippleMaxRadius{80.f};
-  QColor rippleColor{255, 255, 255, 150};
+  QColor rippleColor{255, 251, 224, 150};
   int strokeWidth{3};
-  QColor strokeColor{170, 170, 170};
+  QColor strokeColor{255, 251, 224};
   float fadeRate{0.005f};
-  QColor backgroundTint{255, 255, 255, 40};
+  QColor backgroundTint{34, 34, 34, 120};
 };
 
 class CanvasWindow : public QWidget {
@@ -280,8 +280,10 @@ protected:
         p.drawPath(s.path);
       }
     }
-    if (!m_predictionPath.isEmpty()) {
-      QPen dashPen(QColor(200, 200, 200), 1, Qt::DashLine);
+    if (!m_predictionPath.isEmpty() && m_predictionOpacity > 0.f) {
+      QColor predColor(200, 200, 200);
+      predColor.setAlphaF(m_predictionOpacity);
+      QPen dashPen(predColor, 1, Qt::DashLine);
       p.setPen(dashPen);
       p.drawPath(m_predictionPath);
     }
@@ -321,6 +323,10 @@ private slots:
                                      return s.opacity <= 0.f;
                                    }),
                     m_strokes.end());
+    if (m_predictionOpacity > 0.f)
+      m_predictionOpacity -= 0.05f;
+    if (m_predictionOpacity < 0.f)
+      m_predictionOpacity = 0.f;
     update();
   }
 
@@ -384,6 +390,7 @@ private:
       pred.addEllipse(box.center(), box.width() / 4.0, box.height() / 4.0);
     }
     m_predictionPath = pred;
+    m_predictionOpacity = 1.f;
   }
 
   sc::InputManager m_input;
@@ -443,6 +450,7 @@ private:
   QShortcut *m_togglePrediction;
   bool m_showPrediction{true};
   QPainterPath m_predictionPath;
+  float m_predictionOpacity{0.f};
   bool m_dragging;
   bool m_resizing;
   bool m_pressPending;

--- a/apps/desktop/main.cpp
+++ b/apps/desktop/main.cpp
@@ -15,11 +15,11 @@ int main(int argc, char** argv) {
     QCommandLineOption rippleMaxOpt({"m", "ripple-max"},
         "Maximum ripple radius", "radius", "80.0");
     QCommandLineOption rippleColorOpt({"c", "ripple-color"},
-        "Ripple color (hex)", "color", "#ffffff96");
+        "Ripple color (hex)", "color", "#fffbe096");
     QCommandLineOption strokeWidthOpt({"w", "stroke-width"},
         "Stroke width", "width", "3");
     QCommandLineOption strokeColorOpt({"s", "stroke-color"},
-        "Stroke color (hex)", "color", "#ffffff");
+        "Stroke color (hex)", "color", "#fffbe0");
     QCommandLineOption fadeRateOpt({"f", "fade-rate"},
         "Stroke fade per frame", "rate", "0.005");
 
@@ -36,10 +36,10 @@ int main(int argc, char** argv) {
     opts.rippleGrowthRate = parser.value(rippleGrowthOpt).toFloat();
     opts.rippleMaxRadius = parser.value(rippleMaxOpt).toFloat();
     opts.rippleColor = QColor(parser.value(rippleColorOpt));
-    if (!opts.rippleColor.isValid()) opts.rippleColor = QColor("#ffffff96");
+    if (!opts.rippleColor.isValid()) opts.rippleColor = QColor("#fffbe096");
     opts.strokeWidth = parser.value(strokeWidthOpt).toInt();
     opts.strokeColor = QColor(parser.value(strokeColorOpt));
-    if (!opts.strokeColor.isValid()) opts.strokeColor = QColor("#ffffff");
+    if (!opts.strokeColor.isValid()) opts.strokeColor = QColor("#fffbe0");
     opts.fadeRate = parser.value(fadeRateOpt).toFloat();
 
     sc::log(sc::LogLevel::Info, "SymbolCast Desktop starting");


### PR DESCRIPTION
## Summary
- use dark grey canvas background and soft yellow stroke
- fade prediction overlay in and out
- document new color defaults

## Testing
- `cmake ..` *(fails: Qt5 package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460227261c832f9dbe977be6cb85f9