### PR TITLE
Deduplicate ONNX Runtime include guard

### DIFF
--- a/core/recognition/ModelRunner.hpp
+++ b/core/recognition/ModelRunner.hpp
@@ -11,64 +11,6 @@
 #endif
 
 // TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
-
-// TODO: refactor for dynamic input size and model versioning
-#ifdef SC_USE_ONNXRUNTIME
-#  include <onnxruntime_cxx_api.h>
-#endif
 
 namespace sc {
 


### PR DESCRIPTION
## Summary
- clean up duplicate `SC_USE_ONNXRUNTIME` blocks in `ModelRunner.hpp`

## Testing
- `cmake ..` *(fails: could not find Qt5)*

------
https://chatgpt.com/codex/tasks/task_e_684609df3518832faa649c722506f532