### PR TITLE
Add detection color CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can customize the appearance of ripples and strokes:
 --stroke-width <px>      Stroke width in pixels (default: 3)
 --stroke-color <hex>     Stroke color in hex (default: #fffbe0)
 --fade-rate <rate>       Stroke fade per frame (default: 0.005)
+--detection-color <hex>  Detection box color in hex (default: #ffffff66)
 ```
 
 An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a soft yellow trace follows your finger and gradually fades away so you can write multi-stroke symbols. Tap once to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.

--- a/apps/desktop/main.cpp
+++ b/apps/desktop/main.cpp
@@ -22,6 +22,8 @@ int main(int argc, char** argv) {
         "Stroke color (hex)", "color", "#fffbe0");
     QCommandLineOption fadeRateOpt({"f", "fade-rate"},
         "Stroke fade per frame", "rate", "0.005");
+    QCommandLineOption detectionColorOpt({"d", "detection-color"},
+        "Detection box color (hex)", "color", "#ffffff66");
 
     parser.addOption(rippleGrowthOpt);
     parser.addOption(rippleMaxOpt);
@@ -29,6 +31,7 @@ int main(int argc, char** argv) {
     parser.addOption(strokeWidthOpt);
     parser.addOption(strokeColorOpt);
     parser.addOption(fadeRateOpt);
+    parser.addOption(detectionColorOpt);
 
     parser.process(app);
 
@@ -41,6 +44,9 @@ int main(int argc, char** argv) {
     opts.strokeColor = QColor(parser.value(strokeColorOpt));
     if (!opts.strokeColor.isValid()) opts.strokeColor = QColor("#fffbe0");
     opts.fadeRate = parser.value(fadeRateOpt).toFloat();
+    opts.detectionColor = QColor(parser.value(detectionColorOpt));
+    if (!opts.detectionColor.isValid())
+        opts.detectionColor = QColor("#ffffff66");
 
     sc::log(sc::LogLevel::Info, "SymbolCast Desktop starting");
     CanvasWindow win(opts);


### PR DESCRIPTION
## Summary
- add detection color command line option to desktop app
- document `--detection-color` flag in README

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684609e1d304832fbd1769e7b0622b64