### PR TITLE
Enhance logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ You can customize the appearance of ripples and strokes:
 ```
 
 An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a soft yellow trace follows your finger and gradually fades away so you can write multi-stroke symbols. Tap once to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.
+#### Logging
+
+SymbolCast prints timestamped log messages to the console. Control the verbosity with the `SC_LOG_LEVEL` environment variable (`DEBUG`, `INFO`, `WARN`, or `ERROR`). Example:
+
+```bash
+SC_LOG_LEVEL=DEBUG ./symbolcast-desktop
+```
+
+Use this to capture detailed events when troubleshooting gesture input or model issues.
 
 ### Build and run the VR app
 ```bash

--- a/apps/desktop/CanvasWindow.hpp
+++ b/apps/desktop/CanvasWindow.hpp
@@ -128,7 +128,7 @@ protected:
     if (event->button() == Qt::LeftButton) {
       int edges = edgesForPos(event->pos());
       if (edges != EdgeNone) {
-        sc::log(sc::LogLevel::Info, "Resize start");
+        SC_LOG(sc::LogLevel::Info, "Resize start");
         m_resizing = true;
         m_resizeEdges = edges;
         m_originPos = event->globalPos();
@@ -152,16 +152,16 @@ protected:
     if (!wasCapturing && nowCapturing) {
       m_pressPending = false;
       m_dragging = false;
-      sc::log(sc::LogLevel::Info, "Capture started");
+      SC_LOG(sc::LogLevel::Info, "Capture started");
       m_strokes.clear();
       m_strokes.push_back({});
       m_strokes.back().addPoint(event->pos());
       m_input.addPoint(event->pos().x(), event->pos().y());
-      sc::log(sc::LogLevel::Info, "Point " + std::to_string(event->pos().x()) + "," + std::to_string(event->pos().y()));
+      SC_LOG(sc::LogLevel::Info, "Point " + std::to_string(event->pos().x()) + "," + std::to_string(event->pos().y()));
       m_label->hide();
       updatePrediction();
     } else if (wasCapturing && !nowCapturing) {
-      sc::log(sc::LogLevel::Info, "Capture ended");
+      SC_LOG(sc::LogLevel::Info, "Capture ended");
       onSubmit();
       m_predictionPath = QPainterPath();
     } else if (nowCapturing) {
@@ -169,7 +169,7 @@ protected:
         m_strokes.push_back({});
       m_strokes.back().addPoint(event->pos());
       m_input.addPoint(event->pos().x(), event->pos().y());
-      sc::log(sc::LogLevel::Info, "Point " + std::to_string(event->pos().x()) + "," + std::to_string(event->pos().y()));
+      SC_LOG(sc::LogLevel::Info, "Point " + std::to_string(event->pos().x()) + "," + std::to_string(event->pos().y()));
       m_label->hide();
       updatePrediction();
     }
@@ -196,7 +196,7 @@ protected:
     }
     if (m_pressPending && (event->buttons() & Qt::LeftButton)) {
       if ((event->globalPos() - m_pressPos).manhattanLength() > 3) {
-        sc::log(sc::LogLevel::Info, "Drag start");
+        SC_LOG(sc::LogLevel::Info, "Drag start");
         m_dragging = true;
         m_pressPending = false;
       }
@@ -225,7 +225,7 @@ protected:
         m_strokes.push_back({});
       m_strokes.back().addPoint(event->pos());
       m_input.addPoint(event->pos().x(), event->pos().y());
-      sc::log(sc::LogLevel::Info, "Point " + std::to_string(event->pos().x()) + "," + std::to_string(event->pos().y()));
+      SC_LOG(sc::LogLevel::Info, "Point " + std::to_string(event->pos().x()) + "," + std::to_string(event->pos().y()));
       m_label->hide();
       updatePrediction();
     }
@@ -234,9 +234,9 @@ protected:
   void mouseReleaseEvent(QMouseEvent *event) override {
     if (event->button() == Qt::LeftButton) {
       if (m_dragging)
-        sc::log(sc::LogLevel::Info, "Drag end");
+        SC_LOG(sc::LogLevel::Info, "Drag end");
       if (m_resizing)
-        sc::log(sc::LogLevel::Info, "Resize end");
+        SC_LOG(sc::LogLevel::Info, "Resize end");
       m_dragging = false;
       m_resizing = false;
       m_pressPending = false;
@@ -304,12 +304,12 @@ private slots:
       return;
     sc::ModelRunner runner;
     if (!runner.loadModel("models/symbolcast-v1.onnx")) {
-      sc::log(sc::LogLevel::Error, "Failed to load model");
+      SC_LOG(sc::LogLevel::Error, "Failed to load model");
       return;
     }
     auto sym = runner.run(m_input.points());
     auto cmd = runner.commandForSymbol(sym);
-    sc::log(sc::LogLevel::Info, std::string("Detected symbol: ") + sym +
+    SC_LOG(sc::LogLevel::Info, std::string("Detected symbol: ") + sym +
                                      ", command: " + cmd);
     m_input.clear();
     m_detectionRect = QRectF();

--- a/apps/desktop/main.cpp
+++ b/apps/desktop/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
     if (!opts.detectionColor.isValid())
         opts.detectionColor = QColor("#ffffff66");
 
-    sc::log(sc::LogLevel::Info, "SymbolCast Desktop starting");
+    SC_LOG(sc::LogLevel::Info, "SymbolCast Desktop starting");
     CanvasWindow win(opts);
     win.show();
     return app.exec();

--- a/apps/vr/main.cpp
+++ b/apps/vr/main.cpp
@@ -6,11 +6,11 @@
 // TODO: replace placeholder data with actual OpenXR-based capture loop
 
 int main() {
-    sc::log(sc::LogLevel::Info, "SymbolCast VR starting");
+    SC_LOG(sc::LogLevel::Info, "SymbolCast VR starting");
     sc::InputManager input;
     sc::VRInputManager vrInput;
     if (!vrInput.connectController()) {
-        sc::log(sc::LogLevel::Error, "Failed to connect VR controller");
+        SC_LOG(sc::LogLevel::Error, "Failed to connect VR controller");
         return 1;
     }
     sc::ModelRunner model;
@@ -26,10 +26,10 @@ int main() {
     vrInput.stopCapture();
     vrInput.exportCSV("captured_vr_gesture.csv");
 
-    sc::log(sc::LogLevel::Info, "Playing back captured path:");
+    SC_LOG(sc::LogLevel::Info, "Playing back captured path:");
     input.playbackPath();
     // VR path would be processed separately; reuse 2D for model demo
     auto symbol = model.run(input.points());
-    sc::log(sc::LogLevel::Info, std::string("Detected symbol: ") + symbol);
+    SC_LOG(sc::LogLevel::Info, std::string("Detected symbol: ") + symbol);
     return 0;
 }

--- a/utils/Logger.hpp
+++ b/utils/Logger.hpp
@@ -1,22 +1,73 @@
 #pragma once
+#include <chrono>
+#include <ctime>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
+#include <cstdlib>
 
 namespace sc {
 
-enum class LogLevel { Info, Warn, Error };
+enum class LogLevel { Debug = 0, Info = 1, Warn = 2, Error = 3 };
 
-inline void log(LogLevel level, const std::string& msg) {
+inline LogLevel &globalLogLevel() {
+    static LogLevel level = [] {
+        const char *env = std::getenv("SC_LOG_LEVEL");
+        if (!env)
+            return LogLevel::Info;
+        std::string val(env);
+        if (val == "DEBUG")
+            return LogLevel::Debug;
+        if (val == "WARN")
+            return LogLevel::Warn;
+        if (val == "ERROR")
+            return LogLevel::Error;
+        return LogLevel::Info;
+    }();
+    return level;
+}
+
+inline void setLogLevel(LogLevel level) { globalLogLevel() = level; }
+
+inline const char *levelTag(LogLevel level) {
     switch (level) {
+    case LogLevel::Debug:
+        return "DEBUG";
     case LogLevel::Info:
-        std::cout << "[INFO] " << msg << std::endl;
-        break;
+        return "INFO";
     case LogLevel::Warn:
-        std::cout << "[WARN] " << msg << std::endl;
-        break;
+        return "WARN";
     case LogLevel::Error:
-        std::cerr << "[ERROR] " << msg << std::endl;
-        break;
+        return "ERROR";
     }
+    return "INFO";
+}
+
+inline std::string currentTime() {
+    auto now = std::chrono::system_clock::now();
+    auto t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &t);
+#else
+    localtime_r(&t, &tm);
+#endif
+    std::ostringstream ss;
+    ss << std::put_time(&tm, "%F %T");
+    return ss.str();
+}
+
+inline void log(LogLevel level, const std::string &msg,
+                const char *file = nullptr, int line = 0) {
+    if (static_cast<int>(level) < static_cast<int>(globalLogLevel()))
+        return;
+    std::ostream &out = (level == LogLevel::Error ? std::cerr : std::cout);
+    out << '[' << levelTag(level) << "] " << currentTime();
+    if (file)
+        out << ' ' << file << ':' << line;
+    out << " " << msg << std::endl;
 }
 
 } // namespace sc
+
+#define SC_LOG(level, msg) ::sc::log(level, msg, __FILE__, __LINE__)


### PR DESCRIPTION
## Summary
- introduce timestamped logger with configurable log level
- use `SC_LOG` macro across apps
- document `SC_LOG_LEVEL` in README

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6846d2427478832f9ad991075b099a36