### PR TITLE
Add 404 tracking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ Use this to capture detailed events when troubleshooting gesture input or model 
 Use `scripts/track_404.py` to find frequently requested paths that return 404.
 The script strips query parameters and anonymizes any digits so personal data
 is not leaked. Multiple log files can be analyzed at once and gzipped logs are
-supported.
+supported. Results may also be written to a file using ``-o``.
 
 ```bash
-python scripts/track_404.py access.log other.log.gz -m 10 -n 20
+python scripts/track_404.py access.log other.log.gz -m 10 -n 20 -o results.txt
 ```
 The options control the minimum number of hits (`-m`) and how many results to
 display (`-n`, `0` for all). Paths containing numbers are reported with

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ SC_LOG_LEVEL=DEBUG ./symbolcast-desktop
 
 Use this to capture detailed events when troubleshooting gesture input or model issues.
 
+### 404 Error Tracking
+
+`scripts/track_404.py` summarizes repeated 404 responses in any HTTP access log without exposing private details.
+
+```bash
+python scripts/track_404.py /path/to/access.log 10
+```
+Paths exceeding the optional threshold (default: 5) are printed with their hit counts.
+
 ### Build and run the VR app
 ```bash
 make symbolcast-vr

--- a/README.md
+++ b/README.md
@@ -94,12 +94,16 @@ Use this to capture detailed events when troubleshooting gesture input or model 
 
 ### 404 Error Tracking
 
-`scripts/track_404.py` summarizes repeated 404 responses in any HTTP access log without exposing private details.
+Use `scripts/track_404.py` to find frequently requested paths that return 404.
+The script strips query parameters and anonymizes any digits so personal data
+is not leaked.
 
 ```bash
-python scripts/track_404.py /path/to/access.log 10
+python scripts/track_404.py /path/to/access.log -m 10 -n 20
 ```
-Paths exceeding the optional threshold (default: 5) are printed with their hit counts.
+The options control the minimum number of hits (`-m`) and how many results to
+display (`-n`, `0` for all). Paths containing numbers are reported with
+`<num>` placeholders to avoid exposing IDs.
 
 ### Build and run the VR app
 ```bash

--- a/README.md
+++ b/README.md
@@ -96,14 +96,16 @@ Use this to capture detailed events when troubleshooting gesture input or model 
 
 Use `scripts/track_404.py` to find frequently requested paths that return 404.
 The script strips query parameters and anonymizes any digits so personal data
-is not leaked.
+is not leaked. Multiple log files can be analyzed at once and gzipped logs are
+supported.
 
 ```bash
-python scripts/track_404.py /path/to/access.log -m 10 -n 20
+python scripts/track_404.py access.log other.log.gz -m 10 -n 20
 ```
 The options control the minimum number of hits (`-m`) and how many results to
 display (`-n`, `0` for all). Paths containing numbers are reported with
-`<num>` placeholders to avoid exposing IDs.
+`<num>` placeholders to avoid exposing IDs. Pass `-` in place of a filename to
+read from standard input.
 
 ### Build and run the VR app
 ```bash

--- a/scripts/track_404.py
+++ b/scripts/track_404.py
@@ -2,23 +2,41 @@
 """Summarize repeated 404 errors without exposing user data."""
 
 import argparse
+import gzip
 import re
+import sys
 from collections import Counter
 from pathlib import Path
 
-HTTP_PATTERN = re.compile(r'"(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) ([^ ]+) HTTP/[0-9.]+" 404')
+HTTP_PATTERN = re.compile(
+    r'"(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) ([^ ]+) HTTP/[0-9.]+" 404'
+)
 
 
 def sanitize_path(path: str) -> str:
     """Remove query params and replace digits with '<num>'."""
-    path = path.split('?', 1)[0]
-    return re.sub(r'\d+', '<num>', path)
+    path = path.split("?", 1)[0]
+    return re.sub(r"\d+", "<num>", path)
 
 
-def summarize_404(log_path: Path, min_count: int = 5, top: int = 0) -> None:
+def _iter_lines(log_path: Path):
+    if str(log_path) == "-":
+        for line in sys.stdin:
+            yield line
+    elif str(log_path).endswith(".gz"):
+        with gzip.open(log_path, "rt", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                yield line
+    else:
+        with log_path.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                yield line
+
+
+def summarize_404(log_paths: list[Path], min_count: int = 5, top: int = 0) -> None:
     counts: Counter[str] = Counter()
-    with log_path.open('r', errors='ignore') as handle:
-        for line in handle:
+    for path in log_paths:
+        for line in _iter_lines(path):
             m = HTTP_PATTERN.search(line)
             if m:
                 counts[sanitize_path(m.group(1))] += 1
@@ -35,12 +53,27 @@ def summarize_404(log_path: Path, min_count: int = 5, top: int = 0) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Analyze repeated 404s in an access log")
-    parser.add_argument("log", type=Path, help="Path to access log file")
-    parser.add_argument("--min-count", "-m", type=int, default=5, help="Minimum hits required to display")
-    parser.add_argument("--top", "-n", type=int, default=0, help="Show only the top N paths (0 for all)")
+    parser = argparse.ArgumentParser(
+        description="Analyze repeated 404s in one or more access logs"
+    )
+    parser.add_argument(
+        "logs",
+        nargs="+",
+        type=Path,
+        help="Log file(s) to read or '-' for standard input",
+    )
+    parser.add_argument(
+        "--min-count",
+        "-m",
+        type=int,
+        default=5,
+        help="Minimum hits required to display",
+    )
+    parser.add_argument(
+        "--top", "-n", type=int, default=0, help="Show only the top N paths (0 for all)"
+    )
     args = parser.parse_args()
-    summarize_404(args.log, args.min_count, args.top)
+    summarize_404(args.logs, args.min_count, args.top)
 
 
 if __name__ == "__main__":

--- a/scripts/track_404.py
+++ b/scripts/track_404.py
@@ -1,30 +1,47 @@
 #!/usr/bin/env python3
-"""Track repeated 404 errors without storing user info."""
+"""Summarize repeated 404 errors without exposing user data."""
 
+import argparse
 import re
-import sys
 from collections import Counter
+from pathlib import Path
 
 HTTP_PATTERN = re.compile(r'"(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) ([^ ]+) HTTP/[0-9.]+" 404')
 
 
-def summarize_404(log_path: str, threshold: int = 5):
-    counts = Counter()
-    with open(log_path, 'r', errors='ignore') as f:
-        for line in f:
+def sanitize_path(path: str) -> str:
+    """Remove query params and replace digits with '<num>'."""
+    path = path.split('?', 1)[0]
+    return re.sub(r'\d+', '<num>', path)
+
+
+def summarize_404(log_path: Path, min_count: int = 5, top: int = 0) -> None:
+    counts: Counter[str] = Counter()
+    with log_path.open('r', errors='ignore') as handle:
+        for line in handle:
             m = HTTP_PATTERN.search(line)
             if m:
-                path = m.group(1).split('?')[0]
-                counts[path] += 1
-    for path, count in sorted(counts.items(), key=lambda x: -x[1]):
-        if count >= threshold:
-            print(f"{path}: {count} hits")
+                counts[sanitize_path(m.group(1))] += 1
+
+    items = sorted(counts.items(), key=lambda x: -x[1])
+    shown = 0
+    for path, count in items:
+        if count < min_count:
+            break
+        print(f"{path}: {count} hits")
+        shown += 1
+        if top and shown >= top:
+            break
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze repeated 404s in an access log")
+    parser.add_argument("log", type=Path, help="Path to access log file")
+    parser.add_argument("--min-count", "-m", type=int, default=5, help="Minimum hits required to display")
+    parser.add_argument("--top", "-n", type=int, default=0, help="Show only the top N paths (0 for all)")
+    args = parser.parse_args()
+    summarize_404(args.log, args.min_count, args.top)
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Usage: track_404.py <access_log> [threshold]", file=sys.stderr)
-        sys.exit(1)
-    file_path = sys.argv[1]
-    thr = int(sys.argv[2]) if len(sys.argv) > 2 else 5
-    summarize_404(file_path, thr)
+    main()

--- a/scripts/track_404.py
+++ b/scripts/track_404.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Track repeated 404 errors without storing user info."""
+
+import re
+import sys
+from collections import Counter
+
+HTTP_PATTERN = re.compile(r'"(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) ([^ ]+) HTTP/[0-9.]+" 404')
+
+
+def summarize_404(log_path: str, threshold: int = 5):
+    counts = Counter()
+    with open(log_path, 'r', errors='ignore') as f:
+        for line in f:
+            m = HTTP_PATTERN.search(line)
+            if m:
+                path = m.group(1).split('?')[0]
+                counts[path] += 1
+    for path, count in sorted(counts.items(), key=lambda x: -x[1]):
+        if count >= threshold:
+            print(f"{path}: {count} hits")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: track_404.py <access_log> [threshold]", file=sys.stderr)
+        sys.exit(1)
+    file_path = sys.argv[1]
+    thr = int(sys.argv[2]) if len(sys.argv) > 2 else 5
+    summarize_404(file_path, thr)

--- a/scripts/track_404.py
+++ b/scripts/track_404.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Summarize repeated 404 errors without exposing user data."""
+"""Summarize repeated 404 errors without exposing user data.
+
+The script aggregates paths that generated 404 responses across one or more
+access logs. Query parameters are stripped and all numeric segments are
+replaced with ``<num>`` so that private identifiers do not appear in the
+output.
+"""
 
 import argparse
 import gzip
@@ -7,6 +13,7 @@ import re
 import sys
 from collections import Counter
 from pathlib import Path
+from typing import Iterable, List, Tuple
 
 HTTP_PATTERN = re.compile(
     r'"(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) ([^ ]+) HTTP/[0-9.]+" 404'
@@ -14,42 +21,48 @@ HTTP_PATTERN = re.compile(
 
 
 def sanitize_path(path: str) -> str:
-    """Remove query params and replace digits with '<num>'."""
+    """Strip query parameters and anonymize numbers in *path*."""
     path = path.split("?", 1)[0]
     return re.sub(r"\d+", "<num>", path)
 
 
-def _iter_lines(log_path: Path):
+def _iter_lines(log_path: Path) -> Iterable[str]:
+    """Yield lines from ``log_path`` supporting ``-`` and gzip files."""
     if str(log_path) == "-":
         for line in sys.stdin:
             yield line
     elif str(log_path).endswith(".gz"):
-        with gzip.open(log_path, "rt", encoding="utf-8", errors="ignore") as f:
-            for line in f:
+        with gzip.open(log_path, "rt", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
                 yield line
     else:
-        with log_path.open("r", encoding="utf-8", errors="ignore") as f:
-            for line in f:
+        with log_path.open("r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
                 yield line
 
 
-def summarize_404(log_paths: list[Path], min_count: int = 5, top: int = 0) -> None:
+def summarize_404(
+    log_paths: Iterable[Path], min_count: int = 5, top: int = 0
+) -> List[Tuple[str, int]]:
+    """Return a sorted list of ``(path, count)`` tuples for repeated 404s."""
     counts: Counter[str] = Counter()
-    for path in log_paths:
-        for line in _iter_lines(path):
-            m = HTTP_PATTERN.search(line)
-            if m:
-                counts[sanitize_path(m.group(1))] += 1
+    for file_path in log_paths:
+        for line in _iter_lines(file_path):
+            match = HTTP_PATTERN.search(line)
+            if match:
+                counts[sanitize_path(match.group(1))] += 1
 
     items = sorted(counts.items(), key=lambda x: -x[1])
+    results: List[Tuple[str, int]] = []
     shown = 0
-    for path, count in items:
+    for p, count in items:
         if count < min_count:
             break
-        print(f"{path}: {count} hits")
+        results.append((p, count))
         shown += 1
         if top and shown >= top:
             break
+    return results
 
 
 def main() -> None:
@@ -72,8 +85,21 @@ def main() -> None:
     parser.add_argument(
         "--top", "-n", type=int, default=0, help="Show only the top N paths (0 for all)"
     )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Write results to a file instead of stdout",
+    )
     args = parser.parse_args()
-    summarize_404(args.logs, args.min_count, args.top)
+    results = summarize_404(args.logs, args.min_count, args.top)
+    out_lines = [f"{p}: {c} hits\n" for p, c in results]
+    if args.output:
+        args.output.write_text("".join(out_lines), encoding="utf-8")
+    else:
+        for line in out_lines:
+            print(line, end="")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `scripts/track_404.py` for summarizing repeated 404 responses
- document the new script in the README

## Testing
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684712cb3ed0832fb5f688870ad86957