### PR TITLE
Improve 404 log analysis script

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,20 +92,22 @@ SC_LOG_LEVEL=DEBUG ./symbolcast-desktop
 
 Use this to capture detailed events when troubleshooting gesture input or model issues.
 
-### 404 Error Tracking
+### HTTP Error Tracking
 
-Use `scripts/track_404.py` to find frequently requested paths that return 404.
-The script strips query parameters and anonymizes any digits so personal data
-is not leaked. Multiple log files can be analyzed at once and gzipped logs are
-supported. Results may also be written to a file using ``-o``.
+Use `scripts/track_404.py` to find frequently requested paths that return a
+specific status code (404 by default). The script strips query parameters and
+anonymizes any digits so personal data is not leaked. Multiple log files can be
+analyzed at once and gzipped logs are supported. Results may also be written to
+a file using ``-o``.
 
 ```bash
-python scripts/track_404.py access.log other.log.gz -m 10 -n 20 -o results.txt
+python scripts/track_404.py access.log other.log.gz -m 10 -n 20 \
+    -s 404 -o results.txt
 ```
-The options control the minimum number of hits (`-m`) and how many results to
-display (`-n`, `0` for all). Paths containing numbers are reported with
-`<num>` placeholders to avoid exposing IDs. Pass `-` in place of a filename to
-read from standard input.
+The options control the minimum number of hits (`-m`), how many results to
+display (`-n`, `0` for all), and which status code to track (`-s`). Paths
+containing numbers are reported with `<num>` placeholders to avoid exposing
+IDs. Pass `-` in place of a filename to read from standard input.
 
 ### Build and run the VR app
 ```bash

--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ SC_LOG_LEVEL=DEBUG ./symbolcast-desktop
 
 Use this to capture detailed events when troubleshooting gesture input or model issues.
 
+### 404 Error Tracking
+
+Use `scripts/track_404.py` to find frequently requested paths that return 404.
+The script strips query parameters and anonymizes any digits so personal data
+is not leaked. Multiple log files can be analyzed at once and gzipped logs are
+supported. Results may also be written to a file using ``-o``.
+
+```bash
+python scripts/track_404.py access.log other.log.gz -m 10 -n 20 -o results.txt
+```
+The options control the minimum number of hits (`-m`) and how many results to
+display (`-n`, `0` for all). Paths containing numbers are reported with
+`<num>` placeholders to avoid exposing IDs. Pass `-` in place of a filename to
+read from standard input.
+
 ### Build and run the VR app
 ```bash
 make symbolcast-vr

--- a/scripts/track_404.py
+++ b/scripts/track_404.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Summarize repeated 404 errors without exposing user data.
+
+The script aggregates paths that generated 404 responses across one or more
+access logs. Query parameters are stripped and all numeric segments are
+replaced with ``<num>`` so that private identifiers do not appear in the
+output.
+"""
+
+import argparse
+import gzip
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+HTTP_PATTERN = re.compile(
+    r'"(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) ([^ ]+) HTTP/[0-9.]+" 404'
+)
+
+
+def sanitize_path(path: str) -> str:
+    """Strip query parameters and anonymize numbers in *path*."""
+    path = path.split("?", 1)[0]
+    return re.sub(r"\d+", "<num>", path)
+
+
+def _iter_lines(log_path: Path) -> Iterable[str]:
+    """Yield lines from ``log_path`` supporting ``-`` and gzip files."""
+    if str(log_path) == "-":
+        for line in sys.stdin:
+            yield line
+    elif str(log_path).endswith(".gz"):
+        with gzip.open(
+            log_path,
+            "rt",
+            encoding="utf-8",
+            errors="ignore",
+        ) as fh:
+            for line in fh:
+                yield line
+    else:
+        with log_path.open("r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                yield line
+
+
+def summarize_404(
+    log_paths: Iterable[Path], min_count: int = 5, top: int = 0
+) -> List[Tuple[str, int]]:
+    """Return a sorted list of ``(path, count)`` tuples for repeated 404s."""
+    counts: Counter[str] = Counter()
+    for file_path in log_paths:
+        for line in _iter_lines(file_path):
+            match = HTTP_PATTERN.search(line)
+            if match:
+                counts[sanitize_path(match.group(1))] += 1
+
+    items = sorted(counts.items(), key=lambda x: -x[1])
+    results: List[Tuple[str, int]] = []
+    shown = 0
+    for p, count in items:
+        if count < min_count:
+            break
+        results.append((p, count))
+        shown += 1
+        if top and shown >= top:
+            break
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Analyze repeated 404s in one or more access logs"
+    )
+    parser.add_argument(
+        "logs",
+        nargs="+",
+        type=Path,
+        help="Log file(s) to read or '-' for standard input",
+    )
+    parser.add_argument(
+        "--min-count",
+        "-m",
+        type=int,
+        default=5,
+        help="Minimum hits required to display",
+    )
+    parser.add_argument(
+        "--top",
+        "-n",
+        type=int,
+        default=0,
+        help="Show only the top N paths (0 for all)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Write results to a file instead of stdout",
+    )
+    args = parser.parse_args()
+    results = summarize_404(args.logs, args.min_count, args.top)
+    out_lines = [f"{p}: {c} hits\n" for p, c in results]
+    if args.output:
+        args.output.write_text("".join(out_lines), encoding="utf-8")
+    else:
+        for line in out_lines:
+            print(line, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/track_404.py
+++ b/scripts/track_404.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Summarize repeated 404 errors without exposing user data.
+"""Summarize repeated HTTP errors without exposing user data.
 
-The script aggregates paths that generated 404 responses across one or more
-access logs. Query parameters are stripped and all numeric segments are
+The script aggregates paths that generated a chosen status code across one or
+more access logs. Query parameters are stripped and all numeric segments are
 replaced with ``<num>`` so that private identifiers do not appear in the
 output.
 """
@@ -15,9 +15,14 @@ from collections import Counter
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
-HTTP_PATTERN = re.compile(
-    r'"(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) ([^ ]+) HTTP/[0-9.]+" 404'
-)
+
+def build_pattern(status: int) -> re.Pattern[str]:
+    """Return a compiled regex for *status* codes in access logs."""
+    pattern = (
+        r'"(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) ([^ ]+) '
+        r'HTTP/[0-9.]+" {status}'.format(status=status)
+    )
+    return re.compile(pattern)
 
 
 def sanitize_path(path: str) -> str:
@@ -47,13 +52,17 @@ def _iter_lines(log_path: Path) -> Iterable[str]:
 
 
 def summarize_404(
-    log_paths: Iterable[Path], min_count: int = 5, top: int = 0
+    log_paths: Iterable[Path],
+    min_count: int = 5,
+    top: int = 0,
+    status: int = 404,
 ) -> List[Tuple[str, int]]:
-    """Return a sorted list of ``(path, count)`` tuples for repeated 404s."""
+    """Return a sorted list of ``(path, count)`` tuples for repeated errors."""
+    pattern = build_pattern(status)
     counts: Counter[str] = Counter()
     for file_path in log_paths:
         for line in _iter_lines(file_path):
-            match = HTTP_PATTERN.search(line)
+            match = pattern.search(line)
             if match:
                 counts[sanitize_path(match.group(1))] += 1
 
@@ -88,11 +97,19 @@ def main() -> None:
         help="Minimum hits required to display",
     )
     parser.add_argument(
-        "--top",
+        "--limit",
         "-n",
+        dest="limit",
         type=int,
         default=0,
         help="Show only the top N paths (0 for all)",
+    )
+    parser.add_argument(
+        "--status",
+        "-s",
+        type=int,
+        default=404,
+        help="HTTP status code to analyze",
     )
     parser.add_argument(
         "--output",
@@ -102,7 +119,9 @@ def main() -> None:
         help="Write results to a file instead of stdout",
     )
     args = parser.parse_args()
-    results = summarize_404(args.logs, args.min_count, args.top)
+    results = summarize_404(
+        args.logs, args.min_count, args.limit, status=args.status
+    )
     out_lines = [f"{p}: {c} hits\n" for p, c in results]
     if args.output:
         args.output.write_text("".join(out_lines), encoding="utf-8")


### PR DESCRIPTION
## Summary
- allow analyzing multiple log files with optional gzip handling
- sanitize paths and add --output option
- document usage in README
- fix lint issues

## Testing
- `flake8 scripts/track_404.py`
- `cmake -S . -B build` *(fails: Qt5 missing)*
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684712cb3ed0832fb5f688870ad86957