### PR TITLE
Add hybrid recognizer for custom gestures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,4 +58,8 @@ add_executable(test_dynamic_recognizer tests/test_dynamic_recognizer.cpp)
 target_link_libraries(test_dynamic_recognizer PRIVATE symbolcast_core)
 add_test(NAME TestDynamicRecognizer COMMAND test_dynamic_recognizer)
 
+add_executable(test_hybrid_recognizer tests/test_hybrid_recognizer.cpp)
+target_link_libraries(test_hybrid_recognizer PRIVATE symbolcast_core)
+add_test(NAME TestHybridRecognizer COMMAND test_hybrid_recognizer)
+
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Designed to feel like a native extension of the OS, SymbolCast supports both 2D 
 
 - 🖱️ **Multi-input Drawing**: Trackpad, mouse, keyboard stroke path, or VR controller.
 - 🧠 **Model Training Pipeline**: Collect labeled symbol data and train recognition models.
+- 🧩 **Hybrid Recognition**: Built-in core model plus live-trained custom gestures.
 - ⚙️ **Command Mapping**: Bind recognized symbols to OS commands, macros, or scripts.
 - 🧑‍💻 **Native C++ Core**: Built using Qt, OpenXR, and ONNX Runtime for fast performance and full control.
 - 🌐 **Cross-Platform**: Designed for desktop and VR environments with future OS-level integration.

--- a/core/recognition/HybridRecognizer.hpp
+++ b/core/recognition/HybridRecognizer.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include "GestureRecognizer.hpp"
+#include "ModelRunner.hpp"
+
+namespace sc {
+
+// Hybrid recognizer that first checks custom gestures then falls back to the core model.
+class HybridRecognizer {
+public:
+    explicit HybridRecognizer(size_t maxPoints = 16,
+                              const std::string& commandFile = "config/commands.json")
+        : m_custom(maxPoints), m_model(commandFile) {}
+
+    bool loadModel(const std::string& path) { return m_model.loadModel(path); }
+
+    bool loadCustomProfile(const std::string& path) { return m_custom.loadProfile(path); }
+    bool saveCustomProfile(const std::string& path) const { return m_custom.saveProfile(path); }
+
+    void addCustomSample(const std::string& label, const std::vector<Point>& pts,
+                         const std::string& command) {
+        m_custom.addSample(label, pts, command);
+    }
+
+    std::string predict(const std::vector<Point>& pts) const {
+        if (!m_custom.empty()) {
+            std::string lbl = m_custom.predict(pts);
+            if (!lbl.empty())
+                return lbl;
+        }
+        return m_model.run(pts);
+    }
+
+    std::string commandForSymbol(const std::string& symbol) const {
+        std::string cmd = m_custom.commandForLabel(symbol);
+        if (!cmd.empty())
+            return cmd;
+        return m_model.commandForSymbol(symbol);
+    }
+
+    std::string commandForGesture(const std::vector<Point>& pts) const {
+        std::string sym = predict(pts);
+        return commandForSymbol(sym);
+    }
+
+private:
+    GestureRecognizer m_custom;
+    ModelRunner m_model;
+};
+
+} // namespace sc
+

--- a/tests/test_hybrid_recognizer.cpp
+++ b/tests/test_hybrid_recognizer.cpp
@@ -1,0 +1,16 @@
+#include "core/recognition/HybridRecognizer.hpp"
+#include <cassert>
+
+int main() {
+    sc::HybridRecognizer hybrid;
+    std::vector<sc::Point> tri{{0.f,0.f},{1.f,0.f},{0.f,1.f}};
+    hybrid.addCustomSample("mytri", tri, "custom-cmd");
+    std::vector<sc::Point> tri2{{0.f,0.f},{0.9f,0.1f},{0.1f,0.9f}};
+    assert(hybrid.predict(tri2) == "mytri");
+    assert(hybrid.commandForGesture(tri2) == "custom-cmd");
+
+    std::vector<sc::Point> square{{0.f,0.f},{1.f,0.f},{1.f,1.f},{0.f,1.f}};
+    assert(hybrid.predict(square) == "square");
+    assert(hybrid.commandForGesture(square) == "open-menu");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add HybridRecognizer to combine built-in model and user-trained gestures
- provide a test verifying both paths
- compile test in CMake
- document hybrid recognition in README

## Testing
- `cmake ..` *(fails: Qt5 not found)*
- `ctest --output-on-failure` *(fails: no tests due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_684b2ddca934832f8bd0f7f02a3dc54a