### PR TITLE
Add modular model router and multi-tap input system

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Designed to feel like a native extension of the OS, SymbolCast supports both 2D 
 ## ✨ Features
 
 - 🖱️ **Multi-input Drawing**: Trackpad, mouse, keyboard stroke path, or VR controller.
+- 🌀 **Multi-tap Capture**: Double-tap to start, single-tap to separate symbols, double-tap to submit.
 - 🧠 **Model Training Pipeline**: Collect labeled symbol data and train recognition models.
 - 🧩 **Hybrid Recognition**: Built-in core model plus live-trained custom gestures.
+- 📚 **Modular Model Router**: Routes symbols to shape, letter, or gesture models automatically.
 - ⚙️ **Command Mapping**: Bind recognized symbols to OS commands, macros, or scripts.
 - 🧑‍💻 **Native C++ Core**: Built using Qt, OpenXR, and ONNX Runtime for fast performance and full control.
 - 🌐 **Cross-Platform**: Designed for desktop and VR environments with future OS-level integration.
@@ -60,6 +62,7 @@ make
 ./symbolcast-desktop
 ```
 An overlay window sized to your trackpad will appear and your system cursor will be hidden inside it. Any finger motion creates a fading ripple so you can practice moving on the pad. Double tap (or double click) to begin drawing; your movements are captured even without holding the button. Tap once to submit the glowing trace for recognition.
+Use single taps to separate symbols while recording and double tap again to finish the sequence.
 Lifting your finger while drawing clears the current trace so you can reposition and start a new one without leaving drawing mode.
 
 Press **Ctrl+T** after drawing to label the gesture for training. The dialog also lets you choose how many random variations to generate for one-shot learning.
@@ -68,6 +71,7 @@ Press **Ctrl+T** after drawing to label the gesture for training. The dialog als
 
 SymbolCast loads command mappings from `config/commands.json` when it starts.
 Edit this file to change which command is triggered for each recognized symbol.
+Models are listed in `config/models.json` and loaded on demand by the router.
 
 
 #### Command-line options
@@ -146,6 +150,7 @@ python train_symbol_model.py \
     --augment 10
 ```
 Use `--augment` to synthesize jittered copies of each sample during training. The generated model will be written to `models/symbolcast-v1.onnx`. Run this script before launching the apps so a model is available for inference.
+Additional weights can be placed in the `models/` directory and mapped in `config/models.json` for the router to load.
 
 You can split the labeled dataset into training and test sets with
 `scripts/training/split_dataset.py`:

--- a/config/models.json
+++ b/config/models.json
@@ -1,0 +1,4 @@
+{
+  "shape_model": "models/shape_model.onnx",
+  "letter_model": "models/letter_model.onnx"
+}

--- a/core/recognition/GestureRecognizer.hpp
+++ b/core/recognition/GestureRecognizer.hpp
@@ -121,6 +121,25 @@ public:
         return bestLabel;
     }
 
+    std::pair<std::string, float> predictWithDistance(const std::vector<Point>& pts) const {
+        if (m_samples.empty()) return {std::string(), std::numeric_limits<float>::max()};
+        std::vector<float> feat = toFeature(pts);
+        float bestDist = std::numeric_limits<float>::max();
+        std::string bestLabel;
+        for (const auto& s : m_samples) {
+            float dist = 0.f;
+            for (size_t i = 0; i < feat.size(); ++i) {
+                float d = feat[i] - (i < s.points.size() ? s.points[i] : 0.f);
+                dist += d * d;
+            }
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestLabel = s.label;
+            }
+        }
+        return {bestLabel, bestDist};
+    }
+
     std::string commandForLabel(const std::string& label) const {
         for (const auto& s : m_samples)
             if (s.label == label) return s.command;

--- a/core/recognition/HybridRecognizer.hpp
+++ b/core/recognition/HybridRecognizer.hpp
@@ -23,9 +23,9 @@ public:
 
     std::string predict(const std::vector<Point>& pts) const {
         if (!m_custom.empty()) {
-            std::string lbl = m_custom.predict(pts);
-            if (!lbl.empty())
-                return lbl;
+            auto res = m_custom.predictWithDistance(pts);
+            if (!res.first.empty() && res.second < 0.5f)
+                return res.first;
         }
         return m_model.run(pts);
     }

--- a/core/recognition/ModelRunner.hpp
+++ b/core/recognition/ModelRunner.hpp
@@ -37,7 +37,7 @@ public:
     }
 
     // Returns the predicted symbol name.
-    std::string run(const std::vector<Point>& points) {
+    std::string run(const std::vector<Point>& points) const {
         if (points.empty()) return "";
 #ifdef SC_USE_ONNXRUNTIME
         if (session) {

--- a/core/recognition/RecognizerRouter.hpp
+++ b/core/recognition/RecognizerRouter.hpp
@@ -1,0 +1,70 @@
+#pragma once
+#include "ModelRunner.hpp"
+#include <unordered_map>
+#include <string>
+#include <fstream>
+#include <cctype>
+
+namespace sc {
+
+class RecognizerRouter {
+public:
+    explicit RecognizerRouter(const std::string& configFile = "config/models.json") {
+        loadConfig(configFile);
+    }
+
+    bool loadConfig(const std::string& path) {
+        m_models.clear();
+        std::ifstream in(path);
+        if (!in.is_open())
+            return false;
+        std::string content((std::istreambuf_iterator<char>(in)),
+                            std::istreambuf_iterator<char>());
+        size_t pos = 0;
+        while ((pos = content.find('"', pos)) != std::string::npos) {
+            size_t endKey = content.find('"', pos + 1);
+            if (endKey == std::string::npos) break;
+            std::string key = content.substr(pos + 1, endKey - pos - 1);
+            pos = content.find(':', endKey);
+            if (pos == std::string::npos) break;
+            ++pos;
+            while (pos < content.size() && std::isspace(static_cast<unsigned char>(content[pos]))) ++pos;
+            if (pos >= content.size() || content[pos] != '"') continue;
+            size_t endVal = content.find('"', pos + 1);
+            if (endVal == std::string::npos) break;
+            std::string val = content.substr(pos + 1, endVal - pos - 1);
+            m_models[key] = ModelRunner();
+            m_models[key].loadModel(val);
+            pos = endVal + 1;
+        }
+        return !m_models.empty();
+    }
+
+    std::string recognize(const std::vector<Point>& pts, const std::string& mode = "auto") const {
+        std::string chosen = mode;
+        if (mode == "auto") {
+            if (pts.size() <= 6)
+                chosen = "shape_model";
+            else
+                chosen = "letter_model";
+        }
+        auto it = m_models.find(chosen);
+        if (it == m_models.end())
+            return std::string();
+        return it->second.run(pts);
+    }
+
+    std::string commandForSymbol(const std::string& sym) const {
+        for (const auto& kv : m_models) {
+            std::string cmd = kv.second.commandForSymbol(sym);
+            if (!cmd.empty())
+                return cmd;
+        }
+        return std::string();
+    }
+
+private:
+    std::unordered_map<std::string, ModelRunner> m_models;
+};
+
+} // namespace sc


### PR DESCRIPTION
## Summary
- implement `RecognizerRouter` to load multiple models and route predictions
- support multi-tap sequences with new `TapAction` API in `InputManager`
- update `CanvasWindow` with hover feedback and router integration
- adjust gesture recognition fallback threshold
- document new features and add model config file

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68505163e510832f95369c1b2af47046