### PR TITLE
Add fullscreen and cursor animation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ You can customize the appearance of ripples and strokes:
 --stroke-color <hex>     Stroke color in hex (default: #fffbe0)
 --fade-rate <rate>       Stroke fade per frame (default: 0.005)
 --detection-color <hex>  Detection box color in hex (default: #ffffff66)
+--fullscreen             Launch the board fullscreen
+--cursor-animation       Enable cursor ripple animation
 ```
 
 An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a soft yellow trace follows your finger and gradually fades away so you can write multi-stroke symbols. Tap once to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.

--- a/apps/desktop/main.cpp
+++ b/apps/desktop/main.cpp
@@ -24,6 +24,10 @@ int main(int argc, char** argv) {
         "Stroke fade per frame", "rate", "0.005");
     QCommandLineOption detectionColorOpt({"d", "detection-color"},
         "Detection box color (hex)", "color", "#ffffff66");
+    QCommandLineOption fullscreenOpt({"F", "fullscreen"},
+        "Launch the board fullscreen");
+    QCommandLineOption cursorAnimOpt({"a", "cursor-animation"},
+        "Enable cursor animation");
 
     parser.addOption(rippleGrowthOpt);
     parser.addOption(rippleMaxOpt);
@@ -32,6 +36,8 @@ int main(int argc, char** argv) {
     parser.addOption(strokeColorOpt);
     parser.addOption(fadeRateOpt);
     parser.addOption(detectionColorOpt);
+    parser.addOption(fullscreenOpt);
+    parser.addOption(cursorAnimOpt);
 
     parser.process(app);
 
@@ -47,9 +53,14 @@ int main(int argc, char** argv) {
     opts.detectionColor = QColor(parser.value(detectionColorOpt));
     if (!opts.detectionColor.isValid())
         opts.detectionColor = QColor("#ffffff66");
+    opts.fullscreen = parser.isSet(fullscreenOpt);
+    opts.cursorAnimation = parser.isSet(cursorAnimOpt);
 
     SC_LOG(sc::LogLevel::Info, "SymbolCast Desktop starting");
     CanvasWindow win(opts);
-    win.show();
+    if (opts.fullscreen)
+        win.showFullScreen();
+    else
+        win.show();
     return app.exec();
 }


### PR DESCRIPTION
## Summary
- add fullscreen and cursor animation flags to desktop app
- hide window controls when launching fullscreen
- allow cursor ripples only when cursor animation enabled

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_688cf098a264832f9dc87008f5b9e1b3