### PR TITLE
docs: add TrOCR export dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Install the script's Python dependencies before running the export script:
 ```bash
 pip install -r scripts/requirements.txt
 # or
-pip install transformers Pillow
+pip install transformers pillow
 ```
 
 The example `apps/trocr_infer.cpp` shows how to load the TorchScript module with LibTorch,

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Install the script's Python dependencies before running the export script:
 ```bash
 pip install -r scripts/requirements.txt
 # or
-pip install transformers pillow
+pip install transformers Pillow
 ```
 
 The example `apps/trocr_infer.cpp` shows how to load the TorchScript module with LibTorch,

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ Use `scripts/export_trocr.py` to convert the [TrOCR](https://huggingface.co/micr
 model to TorchScript along with its processor files. The traced model and tokenizer can then be
 consumed from C++.
 
+Install the script's Python dependencies before running the export script:
+
+```bash
+pip install -r scripts/requirements.txt
+# or
+pip install transformers Pillow
+```
+
 The example `apps/trocr_infer.cpp` shows how to load the TorchScript module with LibTorch,
 preprocess an image using OpenCV, and decode the output tokens using the Hugging Face tokenizers
 library:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,3 @@
-Pillow
+pillow
 transformers
+

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,2 @@
+pillow
 transformers
-Pillow

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,2 @@
-pillow
+Pillow
 transformers

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+transformers
+Pillow


### PR DESCRIPTION
## Summary
- document required Python packages for TrOCR export
- add scripts/requirements.txt for transformers and Pillow

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6012b1600832fb711b18728ecc338