### PR TITLE
Handle optional Qt desktop build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,13 +21,21 @@ if(SC_USE_ONNXRUNTIME)
   target_compile_definitions(symbolcast_core INTERFACE SC_USE_ONNXRUNTIME)
 endif()
 
-# Desktop application
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+# Desktop application (optional)
+# Try to find Qt6 or Qt5 for building the desktop application. If neither
+# is available, the desktop target will be skipped so that the rest of the
+# project can still be configured and built without Qt.
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets QUIET)
+if(QT_FOUND)
+  find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 
-add_executable(symbolcast-desktop
-    apps/desktop/main.cpp
-    apps/desktop/CanvasWindow.hpp)
-target_link_libraries(symbolcast-desktop PRIVATE symbolcast_core Qt5::Widgets)
+  add_executable(symbolcast-desktop
+      apps/desktop/main.cpp
+      apps/desktop/CanvasWindow.hpp)
+  target_link_libraries(symbolcast-desktop PRIVATE symbolcast_core Qt${QT_VERSION_MAJOR}::Widgets)
+else()
+  message(STATUS "Qt not found; desktop application will not be built")
+endif()
 
 # VR application
 add_executable(symbolcast-vr apps/vr/main.cpp)


### PR DESCRIPTION
## Summary
- Allow building without Qt by attempting to locate Qt6/Qt5 only for the desktop app
- Skip desktop target when Qt is missing and link using the found Qt version

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c609fc99fc832f8d9c596945e7c041