### PR TITLE
Make Qt optional and support Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(SymbolCast LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_AUTOMOC ON)
 
 # Core library (header-only)
 add_library(symbolcast_core INTERFACE)
@@ -27,16 +26,20 @@ endif()
 # dependencies transitively which causes unresolved Qt symbols
 # during linking. Listing them here ensures all required
 # libraries are linked.
-find_package(Qt5 REQUIRED COMPONENTS Widgets Gui Core)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets Gui Core)
+if(QT_FOUND)
+  set(CMAKE_AUTOMOC ON)
+  find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Gui Core)
 
-add_executable(symbolcast-desktop
-    apps/desktop/main.cpp
-    apps/desktop/CanvasWindow.hpp)
-target_link_libraries(symbolcast-desktop PRIVATE
-    symbolcast_core
-    Qt5::Widgets
-    Qt5::Gui
-    Qt5::Core)
+  add_executable(symbolcast-desktop
+      apps/desktop/main.cpp
+      apps/desktop/CanvasWindow.hpp)
+  target_link_libraries(symbolcast-desktop PRIVATE
+      symbolcast_core
+      Qt${QT_VERSION_MAJOR}::Widgets
+      Qt${QT_VERSION_MAJOR}::Gui
+      Qt${QT_VERSION_MAJOR}::Core)
+endif()
 
 # VR application
 add_executable(symbolcast-vr apps/vr/main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,10 @@ if(SC_USE_ONNXRUNTIME)
 endif()
 
 # Desktop application
-# Explicitly link against Qt Core and Gui along with Widgets.
-# Some toolchains, particularly MSVC, do not link these
-# dependencies transitively which causes unresolved Qt symbols
-# during linking. Listing them here ensures all required
-# libraries are linked.
+# Explicitly link against Qt Core and Gui along with Widgets. MSVC and
+# other toolchains may not link these dependencies transitively, leading
+# to unresolved Qt symbols (as seen on Windows CI). Listing them here
+# ensures all required libraries are linked.
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets Gui Core)
 if(QT_FOUND)
   set(CMAKE_AUTOMOC ON)

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ cd symbolcast
 ```
 
 ### 2. Build with CMake
-Install Qt (and optionally ONNX Runtime) for your platform. On macOS you can use
-Homebrew: `brew install qt`. On Windows, install Qt via the official
-installer and ensure `qmake` is in your PATH.
+Install Qt (5 or 6) if you wish to build the desktop GUI. The core library and
+tests build without it. On macOS you can use Homebrew: `brew install qt`. On
+Windows, install Qt via the official installer and ensure `qmake` is in your
+PATH.
 
 ```bash
 mkdir build && cd build
@@ -200,7 +201,7 @@ g++ trocr_infer.cpp -o trocr_infer \
 
 ### 📦 Dependencies
 - C++17 or later
-- Qt 6+ (for GUI)
+- Qt 5 or 6 (optional, for GUI)
 - OpenXR / SteamVR (for VR support)
   - install the OpenXR runtime for your headset and make sure the loader
     libraries are discoverable by CMake


### PR DESCRIPTION
## Summary
- Allow building desktop app with either Qt6 or Qt5
- Skip desktop build when Qt is missing to fix CI
- Document optional Qt requirement in README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68c60d2297e8832fb54877dba9734b66