### PR TITLE
Link Qt Core/Gui explicitly for desktop build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,10 @@ endif()
 
 # Desktop application
 # Explicitly link against Qt Core and Gui along with Widgets. MSVC and
-# other toolchains may not link these dependencies transitively, leading
-# to unresolved Qt symbols (as seen on Windows CI). Listing them here
-# ensures all required libraries are linked.
+# other toolchains may not pull these libraries in transitively, which
+# triggers a flood of "unresolved external symbol" (e.g. LNK2001) errors
+# during linking. Listing them here ensures all required Qt libraries are
+# linked explicitly.
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets Gui Core)
 if(QT_FOUND)
   set(CMAKE_AUTOMOC ON)


### PR DESCRIPTION
## Summary
- Clarify why the desktop target must link against Qt Core and Qt Gui in addition to Qt Widgets
- Ensure comments reference unresolved symbol errors to aid Windows builds

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c611e3dc7c832fb1bac8b6afab55ac