### PR TITLE
Check model file existence before loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ add_executable(test_command_mapping tests/test_command_mapping.cpp)
 target_link_libraries(test_command_mapping PRIVATE symbolcast_core)
 add_test(NAME TestCommandMapping COMMAND test_command_mapping)
 
+add_executable(test_model_loading tests/test_model_loading.cpp)
+target_link_libraries(test_model_loading PRIVATE symbolcast_core)
+add_test(NAME TestModelLoading COMMAND test_model_loading)
+
 add_executable(test_timestamp tests/test_timestamp.cpp)
 target_link_libraries(test_timestamp PRIVATE symbolcast_core)
 add_test(NAME TestTimestamp COMMAND test_timestamp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,10 @@ if(SC_USE_ONNXRUNTIME)
 endif()
 
 # Desktop application
-# Explicitly link against Qt Core and Gui along with Widgets. MSVC and
-# other toolchains may not pull these libraries in transitively, which
-# triggers a flood of "unresolved external symbol" (e.g. LNK2001) errors
-# during linking. Listing them here ensures all required Qt libraries are
-# linked explicitly.
+# MSVC and some other toolchains don't always link Qt dependencies
+# transitively, leading to "unresolved external symbol" (LNK2001) errors.
+# Link Core and Gui explicitly alongside Widgets to ensure all required
+# Qt libraries are included.
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui Widgets)
 if(QT_FOUND)
   set(CMAKE_AUTOMOC ON)

--- a/core/recognition/ModelRunner.hpp
+++ b/core/recognition/ModelRunner.hpp
@@ -23,6 +23,16 @@ public:
 
     bool loadModel(const std::string& path) {
         m_modelPath = path;
+
+        // Ensure the model file actually exists before proceeding. Without
+        // ONNX Runtime enabled the function previously returned `true`
+        // unconditionally, which meant callers had no way of detecting a
+        // missing model and CI tests expecting a failure would pass
+        // incorrectly.
+        std::ifstream file(path, std::ios::binary);
+        if (!file.good())
+            return false;
+
 #ifdef SC_USE_ONNXRUNTIME
         session.reset();
         Ort::SessionOptions opts;

--- a/tests/test_model_loading.cpp
+++ b/tests/test_model_loading.cpp
@@ -1,0 +1,22 @@
+#include "core/recognition/ModelRunner.hpp"
+#include <cassert>
+#include <fstream>
+
+int main() {
+    sc::ModelRunner runner;
+
+    // Loading a non-existent model should fail.
+    assert(!runner.loadModel("missing-model.onnx"));
+
+    // Create a dummy file to simulate a real model and ensure loading succeeds
+    // when the file exists.
+    const char* temp = "dummy-model.onnx";
+    std::ofstream out(temp, std::ios::binary);
+    out << '0';
+    out.close();
+
+    assert(runner.loadModel(temp));
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- guard ModelRunner::loadModel with a file existence check to fail cleanly when models are missing
- add regression test for missing-model handling and wire it into CMake

## Testing
- `cd build && cmake .. && make && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68c6c7ea7914832fabffc41c8e2b0bc6