### PR TITLE
Document updating model config to exported files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Press **Ctrl+T** after drawing to label the gesture for training. The dialog als
 SymbolCast loads command mappings from `config/commands.json` when it starts.
 Edit this file to change which command is triggered for each recognized symbol.
 Models are listed in `config/models.json` and loaded on demand by the router.
+After you export a network, update the JSON entries so each symbol points at the
+exact ONNX or TorchScript file you produced (for example,
+`models/symbolcast-v1.onnx` or `models/symbolcast-v1.ts`).
 
 
 #### Command-line options


### PR DESCRIPTION
## Summary
- remind readers that `config/models.json` must reference the exported ONNX or TorchScript files

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cae7bddf18832f811ee158dacd3420