### PR TITLE
Enable cursor animation by default with opt-out flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can customize the appearance of ripples and strokes:
 --fade-rate <rate>       Stroke fade per frame (default: 0.005)
 --detection-color <hex>  Detection box color in hex (default: #ffffff66)
 --fullscreen             Launch the board fullscreen
---cursor-animation       Enable cursor ripple animation
+--no-cursor-animation    Disable cursor ripple animation (enabled by default)
 ```
 
 An overlay window sized to your trackpad will appear with rounded corners and a thin border. Instructions are shown in light gray until you start drawing. You can drag the window by pressing and then moving while capture is off (dragging only begins after you move, so double taps won't shift the window) or resize it by grabbing an edge. Your system cursor disappears inside the overlay, and any finger motion creates a fading ripple. Double tap (or double click) to begin drawing; a soft yellow trace follows your finger and gradually fades away so you can write multi-stroke symbols. Tap once to submit the trace for recognition. The instructions reappear after a few seconds of inactivity. Press **Esc** or **Ctrl+C** at any time to exit. The console logs when capture starts, each point is recorded, and when a symbol is detected.

--- a/apps/desktop/CanvasWindow.hpp
+++ b/apps/desktop/CanvasWindow.hpp
@@ -36,7 +36,7 @@ struct CanvasWindowOptions {
   QColor backgroundTint{34, 34, 34, 120};
   QColor detectionColor{255, 255, 255, 102};
   bool fullscreen{false};
-  bool cursorAnimation{false};
+  bool cursorAnimation{true};
 };
 
 class CanvasWindow : public QWidget {

--- a/apps/desktop/main.cpp
+++ b/apps/desktop/main.cpp
@@ -26,8 +26,8 @@ int main(int argc, char** argv) {
         "Detection box color (hex)", "color", "#ffffff66");
     QCommandLineOption fullscreenOpt({"F", "fullscreen"},
         "Launch the board fullscreen");
-    QCommandLineOption cursorAnimOpt({"a", "cursor-animation"},
-        "Enable cursor animation");
+    QCommandLineOption disableCursorAnimOpt({"A", "no-cursor-animation"},
+        "Disable cursor animation (enabled by default)");
 
     parser.addOption(rippleGrowthOpt);
     parser.addOption(rippleMaxOpt);
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
     parser.addOption(fadeRateOpt);
     parser.addOption(detectionColorOpt);
     parser.addOption(fullscreenOpt);
-    parser.addOption(cursorAnimOpt);
+    parser.addOption(disableCursorAnimOpt);
 
     parser.process(app);
 
@@ -54,7 +54,8 @@ int main(int argc, char** argv) {
     if (!opts.detectionColor.isValid())
         opts.detectionColor = QColor("#ffffff66");
     opts.fullscreen = parser.isSet(fullscreenOpt);
-    opts.cursorAnimation = parser.isSet(cursorAnimOpt);
+    if (parser.isSet(disableCursorAnimOpt))
+        opts.cursorAnimation = false;
 
     SC_LOG(sc::LogLevel::Info, "SymbolCast Desktop starting");
     CanvasWindow win(opts);


### PR DESCRIPTION
## Summary
- default the desktop canvas cursor animation to on
- add a --no-cursor-animation flag so users can opt out while keeping the new default
- document the new default behavior and flag in the README command-line options

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb2002b564832fa583563d874296cf