### PR TITLE
Reduce noisy point logging in CanvasWindow

### DIFF
--- a/apps/desktop/CanvasWindow.hpp
+++ b/apps/desktop/CanvasWindow.hpp
@@ -306,7 +306,12 @@ protected:
         m_strokes.push_back({});
       m_strokes.back().addPoint(event->pos());
       m_input.addPoint(event->pos().x(), event->pos().y());
-      SC_LOG(sc::LogLevel::Info, "Point " + std::to_string(event->pos().x()) + "," + std::to_string(event->pos().y()));
+      if (static_cast<int>(sc::globalLogLevel()) <=
+          static_cast<int>(sc::LogLevel::Debug)) {
+        SC_LOG(sc::LogLevel::Debug,
+               "Point " + std::to_string(event->pos().x()) + "," +
+                   std::to_string(event->pos().y()));
+      }
       m_label->hide();
       updatePrediction();
     }


### PR DESCRIPTION
## Summary
- demote the per-point logging in CanvasWindow to debug level and guard it behind a log-level check to avoid flooding INFO logs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbf7f5c364832fae6fe7e10c12e4df