### PR TITLE
Ensure recognizer works when model config is missing

### DIFF
--- a/core/recognition/RecognizerRouter.hpp
+++ b/core/recognition/RecognizerRouter.hpp
@@ -10,14 +10,15 @@ namespace sc {
 class RecognizerRouter {
 public:
     explicit RecognizerRouter(const std::string& configFile = "config/models.json") {
-        loadConfig(configFile);
+        if (!loadConfig(configFile))
+            loadFallbackModels();
     }
 
     bool loadConfig(const std::string& path) {
-        m_models.clear();
         std::ifstream in(path);
         if (!in.is_open())
             return false;
+        m_models.clear();
         std::string content((std::istreambuf_iterator<char>(in)),
                             std::istreambuf_iterator<char>());
         size_t pos = 0;
@@ -37,6 +38,8 @@ public:
             m_models[key].loadModel(val);
             pos = endVal + 1;
         }
+        if (m_models.empty())
+            loadFallbackModels();
         return !m_models.empty();
     }
 
@@ -64,6 +67,13 @@ public:
     }
 
 private:
+    void loadFallbackModels() {
+        if (!m_models.empty())
+            return;
+        m_models.emplace("shape_model", ModelRunner());
+        m_models.emplace("letter_model", ModelRunner());
+    }
+
     std::unordered_map<std::string, ModelRunner> m_models;
 };
 


### PR DESCRIPTION
## Summary
- add a fallback setup for the gesture recognizer router when the configured model list cannot be loaded
- keep any previously loaded models if a reload fails and seed stub routers if the parsed config is empty

## Testing
- cmake -S . -B build
- cmake --build build
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68cc2f46ea58832f8c9e1358316855a1