### PR TITLE
Reset drawing on single tap

### DIFF
--- a/apps/desktop/CanvasWindow.hpp
+++ b/apps/desktop/CanvasWindow.hpp
@@ -228,6 +228,13 @@ protected:
       m_strokes.clear();
       m_label->show();
       SC_LOG(sc::LogLevel::Info, "Sequence end");
+    } else if (act == sc::TapAction::ResetDrawing) {
+      m_input.clear();
+      m_strokes.clear();
+      m_predictionPath = QPainterPath();
+      m_detectionRect = QRectF();
+      m_label->show();
+      updatePrediction();
     } else if (act == sc::TapAction::LabelSymbol) {
       onTrainGesture();
     } else if (act == sc::TapAction::RecordStream) {

--- a/core/input/InputManager.hpp
+++ b/core/input/InputManager.hpp
@@ -19,6 +19,7 @@ struct Point {
 // InputManager records gesture points for later recognition or training.
 enum class TapAction {
     None,
+    ResetDrawing,
     StartSequence,
     EndSymbol,
     EndSequence,
@@ -52,6 +53,8 @@ public:
         }
 
         m_lastTap = timestamp;
+        if (!m_capturing)
+            clear();
         return false;
     }
 
@@ -68,7 +71,9 @@ public:
                 return TapAction::StartSequence;
             }
             m_lastTap = timestamp;
-            return TapAction::None;
+            clear();
+            m_tapCount = 0;
+            return TapAction::ResetDrawing;
         }
 
         if (timestamp - m_lastTap > m_doubleTapInterval) {

--- a/tests/test_double_tap.cpp
+++ b/tests/test_double_tap.cpp
@@ -22,5 +22,13 @@ int main() {
     assert(!dbl && mgr.capturing());
     dbl = mgr.onTap(240);
     assert(dbl && !mgr.capturing());
+
+    mgr.startCapture();
+    mgr.addPoint(0.f, 0.f);
+    mgr.addPoint(1.f, 1.f);
+    mgr.stopCapture();
+    assert(!mgr.points().empty());
+    dbl = mgr.onTap(400); // single tap resets drawing when idle
+    assert(!dbl && mgr.points().empty());
     return 0;
 }


### PR DESCRIPTION
## Summary
- clear stored gesture data on single taps while idle and emit a reset action
- update the desktop canvas to clear strokes when a reset tap is received
- extend the double-tap unit test to verify the reset behavior

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68cc3eff18d8832fa696539ec5612dd5