### PR TITLE
Add system tray control for desktop canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Lifting your finger while drawing clears the current trace so you can reposition
 
 Press **Ctrl+T** after drawing to label the gesture for training. The dialog also lets you choose how many random variations to generate for one-shot learning.
 
+When a system tray is available, the desktop app adds a tray icon labeled **Symbol Keyboard** that keeps running after you hide the canvas. Single- or double-click the tray icon (or choose the menu item) to show or hide the window without quitting. Closing the window now hides it in tray mode; use the tray menu’s **Quit** action or the existing keyboard shortcuts (Esc/Ctrl+C) to exit completely. On macOS and Windows the app continues running in the background so you can recall the keyboard later.
+
 ### Configuration
 
 SymbolCast loads command mappings from `config/commands.json` when it starts.

--- a/apps/desktop/main.cpp
+++ b/apps/desktop/main.cpp
@@ -1,8 +1,49 @@
 #include <QApplication>
 #include "CanvasWindow.hpp"
+#include <QAction>
 #include <QCommandLineOption>
 #include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QCursor>
+#include <QIcon>
+#include <QMenu>
+#include <QObject>
+#include <QSignalBlocker>
+#include <QStyle>
+#include <QSystemTrayIcon>
+#include <QString>
 #include "utils/Logger.hpp"
+
+#ifdef Q_OS_MAC
+#include <objc/message.h>
+#include <objc/objc.h>
+#include <objc/runtime.h>
+#endif
+
+namespace {
+
+QIcon trayIconForApp(const QApplication &app) {
+    QIcon icon = QIcon::fromTheme(QStringLiteral("input-keyboard"));
+    if (icon.isNull())
+        icon = app.style()->standardIcon(QStyle::SP_ComputerIcon);
+    return icon;
+}
+
+#ifdef Q_OS_MAC
+void activateMacApplication() {
+    Class nsAppClass = objc_getClass("NSApplication");
+    if (!nsAppClass)
+        return;
+    SEL sharedAppSel = sel_registerName("sharedApplication");
+    id nsApp = ((id(*)(Class, SEL))objc_msgSend)(nsAppClass, sharedAppSel);
+    if (!nsApp)
+        return;
+    SEL activateSel = sel_registerName("activateIgnoringOtherApps:");
+    ((void (*)(id, SEL, BOOL))objc_msgSend)(nsApp, activateSel, YES);
+}
+#endif
+
+} // namespace
 
 int main(int argc, char** argv) {
     QApplication app(argc, argv);
@@ -59,9 +100,81 @@ int main(int argc, char** argv) {
 
     SC_LOG(sc::LogLevel::Info, "SymbolCast Desktop starting");
     CanvasWindow win(opts);
-    if (opts.fullscreen)
-        win.showFullScreen();
-    else
-        win.show();
+
+    auto presentWindow = [&]() {
+        if (opts.fullscreen) {
+            win.showFullScreen();
+        } else if (win.isMinimized()) {
+            win.showNormal();
+        } else {
+            win.show();
+        }
+        win.raise();
+        win.activateWindow();
+#ifdef Q_OS_MAC
+        activateMacApplication();
+#endif
+    };
+
+    const bool trayAvailable = QSystemTrayIcon::isSystemTrayAvailable();
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    if (trayAvailable)
+        QApplication::setQuitOnLastWindowClosed(false);
+#endif
+
+    if (!trayAvailable) {
+        SC_LOG(sc::LogLevel::Warn,
+               "System tray unavailable; window will close the application");
+    } else {
+        auto *trayIcon = new QSystemTrayIcon(trayIconForApp(app), &app);
+        trayIcon->setToolTip(QObject::tr("SymbolCast"));
+
+        auto *trayMenu = new QMenu();
+        QAction *toggleAction = trayMenu->addAction(QObject::tr("Symbol Keyboard"));
+        toggleAction->setCheckable(true);
+        QAction *quitAction = trayMenu->addAction(QObject::tr("Quit"));
+        trayIcon->setContextMenu(trayMenu);
+
+        win.setHideOnClose(true);
+
+        auto toggleVisibility = [&]() {
+            if (win.isVisible() && !win.isMinimized()) {
+                win.hide();
+            } else {
+                presentWindow();
+            }
+        };
+
+        QObject::connect(toggleAction, &QAction::triggered, &win,
+                         [&](bool) { toggleVisibility(); });
+        QObject::connect(quitAction, &QAction::triggered, &app,
+                         [](bool) { QCoreApplication::quit(); });
+
+        QObject::connect(&win, &CanvasWindow::visibilityChanged, toggleAction,
+                         [toggleAction](bool visible) {
+                             QSignalBlocker blocker(toggleAction);
+                             toggleAction->setChecked(visible);
+                         });
+
+        QObject::connect(trayIcon, &QSystemTrayIcon::activated, &win,
+                         [&, trayMenu](QSystemTrayIcon::ActivationReason reason) {
+            switch (reason) {
+            case QSystemTrayIcon::Trigger:
+            case QSystemTrayIcon::DoubleClick:
+                toggleVisibility();
+                break;
+            case QSystemTrayIcon::Context:
+                if (trayMenu && !trayMenu->isVisible())
+                    trayMenu->popup(QCursor::pos());
+                break;
+            default:
+                break;
+            }
+        });
+
+        trayIcon->show();
+    }
+
+    presentWindow();
     return app.exec();
 }


### PR DESCRIPTION
## Summary
- add a desktop system tray icon with show/hide handling for the canvas window, including macOS activation support when toggled
- update CanvasWindow so tray-driven closes hide the window and expose a visibilityChanged signal for menu state sync
- document the tray-based workflow and background behavior in the README

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68d2ac92fc60832f9946d23bce75a021