### PR TITLE
Add macOS service helper and packaging script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.14)
 project(SymbolCast LANGUAGES CXX)
 
+if(APPLE)
+  enable_language(OBJC)
+  if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum macOS version")
+  endif()
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -47,14 +54,45 @@ if(QT_FOUND)
   set(CMAKE_AUTOMOC ON)
   find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
 
-  add_executable(symbolcast-desktop
+  set(symbolcast_desktop_sources
       apps/desktop/main.cpp
       apps/desktop/CanvasWindow.hpp)
+
+  if(APPLE)
+    set(MACOSX_BUNDLE_BUNDLE_NAME "SymbolCast")
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.symbolcast.desktop")
+    set(MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0")
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "1.0")
+    set(MACOSX_BUNDLE_EXECUTABLE_NAME "symbolcast-desktop")
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/apps/desktop/Info.plist.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/symbolcast-desktop-Info.plist @ONLY)
+  endif()
+
+  add_executable(symbolcast-desktop
+      MACOSX_BUNDLE
+      ${symbolcast_desktop_sources})
   target_link_libraries(symbolcast-desktop PRIVATE
       symbolcast_core
       Qt${QT_VERSION_MAJOR}::Core
       Qt${QT_VERSION_MAJOR}::Gui
       Qt${QT_VERSION_MAJOR}::Widgets)
+  if(APPLE)
+    set_target_properties(symbolcast-desktop PROPERTIES
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_BINARY_DIR}/symbolcast-desktop-Info.plist)
+  endif()
+
+  if(APPLE)
+    add_executable(symbolcast-service-macos
+        MACOSX_BUNDLE
+        os/service-macos/main.m
+        os/service-macos/ServiceDelegate.m
+        os/service-macos/ServiceDelegate.h)
+    set_target_properties(symbolcast-service-macos PROPERTIES
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/os/service-macos/Info.plist
+        OUTPUT_NAME symbolcast-service-macos)
+    target_link_libraries(symbolcast-service-macos PRIVATE "-framework Cocoa")
+    add_dependencies(symbolcast-desktop symbolcast-service-macos)
+  endif()
   if(SC_ENABLE_TROCR)
     target_link_libraries(symbolcast-desktop PRIVATE ${TORCH_LIBRARIES} ${TOKENIZERS_LIBRARY})
     add_executable(symbolcast-trocr-infer

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Press **Ctrl+T** after drawing to label the gesture for training. The dialog als
 
 When a system tray is available, the desktop app adds a tray icon labeled **Symbol Keyboard** that keeps running after you hide the canvas. Single- or double-click the tray icon (or choose the menu item) to show or hide the window without quitting. Closing the window now hides it in tray mode; use the tray menu’s **Quit** action or the existing keyboard shortcuts (Esc/Ctrl+C) to exit completely. On macOS and Windows the app continues running in the background so you can recall the keyboard later.
 
+### 4. Package on macOS
+
+The build generates a background helper bundle (`symbolcast-service-macos.app`) that registers a macOS Service used to resurface the Qt window. After building on macOS, run the packaging helper to assemble a signed `.app` bundle that includes the service inside `Contents/Library/Services/`:
+
+```bash
+./scripts/package_macos_app.sh ./build ./dist "Developer ID Application: Your Name (TEAMID)"
+```
+
+Pass `-` as the signing identity for ad-hoc signing or provide a path to an entitlements file as an optional fourth argument. The resulting `dist/SymbolCast.app` embeds the Service bundle so the “Show SymbolCast Keyboard” entry is available under **Services**.
+
 ### Configuration
 
 SymbolCast loads macro bindings from `config/commands.json` when it starts. Each

--- a/apps/desktop/Info.plist.in
+++ b/apps/desktop/Info.plist.in
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>@MACOSX_BUNDLE_EXECUTABLE_NAME@</string>
+    <key>CFBundleIdentifier</key>
+    <string>@MACOSX_BUNDLE_GUI_IDENTIFIER@</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>@MACOSX_BUNDLE_BUNDLE_NAME@</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>@MACOSX_BUNDLE_SHORT_VERSION_STRING@</string>
+    <key>CFBundleVersion</key>
+    <string>@MACOSX_BUNDLE_BUNDLE_VERSION@</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>@CMAKE_OSX_DEPLOYMENT_TARGET@</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/os/service-macos/Info.plist
+++ b/os/service-macos/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>symbolcast-service-macos</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.symbolcast.desktop.service</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>SymbolCast Service</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSBackgroundOnly</key>
+    <true/>
+    <key>NSServices</key>
+    <array>
+        <dict>
+            <key>NSMessage</key>
+            <string>presentSymbolCast</string>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Show SymbolCast Keyboard</string>
+            </dict>
+            <key>NSPortName</key>
+            <string>com.symbolcast.desktop.service</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>public.utf8-plain-text</string>
+                <string>public.file-url</string>
+            </array>
+        </dict>
+    </array>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/os/service-macos/ServiceDelegate.h
+++ b/os/service-macos/ServiceDelegate.h
@@ -1,0 +1,8 @@
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ServiceDelegate : NSObject <NSApplicationDelegate>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/os/service-macos/ServiceDelegate.m
+++ b/os/service-macos/ServiceDelegate.m
@@ -1,0 +1,33 @@
+#import "ServiceDelegate.h"
+
+static NSString *const kSymbolCastServiceName = @"com.symbolcast.desktop.service";
+static NSString *const kPresentWindowNotification = @"com.symbolcast.desktop.presentWindow";
+
+@implementation ServiceDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
+    NSRegisterServicesProvider(self, kSymbolCastServiceName);
+}
+
+- (void)applicationWillTerminate:(NSNotification *)notification {
+    NSUnregisterServicesProvider(kSymbolCastServiceName);
+}
+
+- (void)presentSymbolCast:(NSPasteboard *)pboard
+                 userData:(NSString *)userData
+                    error:(NSString *__autoreleasing  _Nullable *)error {
+    (void)pboard;
+    (void)userData;
+    if (error) {
+        *error = nil;
+    }
+    [[NSDistributedNotificationCenter defaultCenter]
+        postNotificationName:kPresentWindowNotification
+                      object:nil
+                    userInfo:nil
+          deliverImmediately:YES];
+    [NSApp terminate:nil];
+}
+
+@end

--- a/os/service-macos/main.m
+++ b/os/service-macos/main.m
@@ -1,0 +1,12 @@
+#import <Cocoa/Cocoa.h>
+#import "ServiceDelegate.h"
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        NSApplication *app = [NSApplication sharedApplication];
+        ServiceDelegate *delegate = [[ServiceDelegate alloc] init];
+        app.delegate = delegate;
+        [app run];
+    }
+    return 0;
+}

--- a/scripts/package_macos_app.sh
+++ b/scripts/package_macos_app.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <build-dir> <output-dir> <codesign-identity> [entitlements]" >&2
+  exit 1
+fi
+
+BUILD_DIR="$1"
+OUTPUT_DIR="$2"
+IDENTITY="$3"
+ENTITLEMENTS="${4:-}"
+
+APP_BUNDLE_SRC="${BUILD_DIR}/symbolcast-desktop.app"
+SERVICE_BUNDLE_SRC="${BUILD_DIR}/symbolcast-service-macos.app"
+APP_BUNDLE_DEST="${OUTPUT_DIR}/SymbolCast.app"
+SERVICE_DIR_DEST="${APP_BUNDLE_DEST}/Contents/Library/Services"
+SERVICE_BUNDLE_DEST="${SERVICE_DIR_DEST}/SymbolCast Service.app"
+
+if [[ ! -d "${APP_BUNDLE_SRC}" ]]; then
+  echo "Desktop bundle not found at ${APP_BUNDLE_SRC}. Build the project with CMake on macOS first." >&2
+  exit 2
+fi
+
+if [[ ! -d "${SERVICE_BUNDLE_SRC}" ]]; then
+  echo "Service bundle not found at ${SERVICE_BUNDLE_SRC}. Build the project with CMake on macOS first." >&2
+  exit 3
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+rm -rf "${APP_BUNDLE_DEST}"
+cp -R "${APP_BUNDLE_SRC}" "${APP_BUNDLE_DEST}"
+
+mkdir -p "${SERVICE_DIR_DEST}"
+rm -rf "${SERVICE_BUNDLE_DEST}"
+cp -R "${SERVICE_BUNDLE_SRC}" "${SERVICE_BUNDLE_DEST}"
+
+SIGN_ARGS=(--force --options runtime --sign "${IDENTITY}")
+if [[ -n "${ENTITLEMENTS}" ]]; then
+  SIGN_ARGS+=(--entitlements "${ENTITLEMENTS}")
+fi
+
+codesign "${SIGN_ARGS[@]}" "${SERVICE_BUNDLE_DEST}"
+codesign "${SIGN_ARGS[@]}" "${APP_BUNDLE_DEST}"
+
+echo "Packaged ${APP_BUNDLE_DEST} with bundled macOS Service." >&2


### PR DESCRIPTION
## Summary
- add an AppKit helper service bundle that posts a distributed notification to present the Qt window
- update the desktop build to produce macOS bundles and include Info.plist metadata
- add a macOS packaging script that copies the service into the app bundle and codesigns both artifacts

## Testing
- not run (platform-specific tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dca92b09cc832faff7121f01f11620